### PR TITLE
fix(Authentication): Fix using TemplateBuilder and Settings, when Authentication is disabled

### DIFF
--- a/src/lib/api/infrastructure.ts
+++ b/src/lib/api/infrastructure.ts
@@ -3,13 +3,19 @@ import { performServerFetch, performServerFetchLegacy } from 'lib/api/serverFetc
 import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 import { authOptions } from 'authConfig';
 
+
 const initializeRequestOptions = async (bearerToken: string, init?: RequestInit) => {
     init = init || {};
-
-    if (bearerToken) {
+    const isAuthenticationFeatureEnabled = process.env.AUTHENTICATION_FEATURE_FLAG === 'true';
+    if (isAuthenticationFeatureEnabled && bearerToken) {
         init.headers = {
             ...init.headers,
             Authorization: `Bearer ${bearerToken}`,
+        };
+    } else if (!isAuthenticationFeatureEnabled) {
+        init.headers = {
+            ...init.headers,
+            ApiKey: process.env.MNESTIX_BACKEND_API_KEY ? process.env.MNESTIX_BACKEND_API_KEY : '',
         };
     }
 


### PR DESCRIPTION
# Description

MNES-1378
Fixed Problem, when authentication is not used that you can not delete submodel templates and also not use the id creation settings. Every call now has a API Key if there is no authentication.

Fixes # (Issue)

## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
