### PR TITLE
refactor(submodel-visualizations): use user-plugins directory for custom visualizations

### DIFF
--- a/src/user-plugins/submodels/README.md
+++ b/src/user-plugins/submodels/README.md
@@ -1,0 +1,4 @@
+Use this directory to add custom submodel visualizations.
+We recommend to use the submodels IDshort as the name for the submodel visualization folder.
+
+For a complete guide on how to add custom submodel visualizations please have a look at https://github.com/eclipse-mnestix/mnestix-browser/wiki/How-to-create-custom-submodel-visualizations.


### PR DESCRIPTION
# Description

With this PR we propose a structure for user-plugins. For now these will be custom submodel visualizations.

We have a `user-plugins` directory directly in `src`.
This is found more easily than somewhere in `src/app/[locale]/viewer/_components/submodel`.
This directory can later also be used for custom dashboard components etc.
Should we keep the mnestix components in the nested folder? I think it is ok to leave them for now.

You can clone another project directly into the `user-plugins/submodels` folder and the two git projects are kept separate.
Meaning you can easily update mnestix without interfering with the custom visualizations and you can also commit to the inner project without pushing to mnestix.

For now you will need to touch the mapping files.
Should we move them to be somewhere more accessible for the user?

Fixes # (MNES-1420)

## Type of change

-   [x] Minor change (non-breaking change, e.g. documentation adaption)
