### PR TITLE
chore(yarn): update yarn commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,8 +106,8 @@
     "docker:stop": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.test.yml kill",
     "docker:down": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.test.yml down",
     "docker:prune": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.test.yml down -v && docker network prune && docker network rm mnestix-network",
-    "docker:keycloak": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.keycloak.yml up -d",
-    "docker:azure": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.azure_ad.yml up -d"
+    "docker:keycloak": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.keycloak.yml up",
+    "docker:azure": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.azure_ad.yml up"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "docker:test": "docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests up -d --build && docker compose -f compose.yml -f docker-compose/compose.test.yml attach cypress-test",
     "docker:stop": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.test.yml kill",
     "docker:down": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.test.yml down",
-    "docker:prune": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.test.yml down -v && docker network prune && docker network rm mnestix-network",
+    "docker:prune": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.test.yml -f docker-compose/compose.keycloak.yml down -v && docker network prune && docker network rm mnestix-network",
     "docker:keycloak": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.keycloak.yml up",
     "docker:azure": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.azure_ad.yml up"
   },


### PR DESCRIPTION
# Description

Quick cleanup of the yarn commands.
- The keycloak service was not pruned with the prune command.
- Removed the -d detached flag like in all other commands. You can manually add it by calling `yarn docker:keycloak -d`. 

## Type of change

-   [x] Minor change (non-breaking change, e.g. documentation adaption)

# Checklist:

-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
