### PR TITLE
Refactor(submodel visualizations) all existing visualizations use the same props

### DIFF
--- a/src/app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps.ts
+++ b/src/app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps.ts
@@ -1,5 +1,5 @@
 import { Submodel } from '@aas-core-works/aas-core3.0-typescript/types';
 
 export type SubmodelVisualizationProps = {
-    submodel: Submodel;
+    readonly submodel: Submodel;
 };

--- a/src/app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps.ts
+++ b/src/app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps.ts
@@ -1,5 +1,5 @@
 import { Submodel } from '@aas-core-works/aas-core3.0-typescript/types';
 
-export type SubmodelDetailComponentProps = {
-    submodel: Submodel
-}
+export type SubmodelVisualizationProps = {
+    submodel: Submodel;
+};

--- a/src/app/[locale]/viewer/_components/submodel/bill-of-applications/BillOfApplicationsDetail.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/bill-of-applications/BillOfApplicationsDetail.tsx
@@ -1,13 +1,10 @@
-import { Entity, ISubmodelElement, KeyTypes, Submodel } from '@aas-core-works/aas-core3.0-typescript/types';
+import { Entity, ISubmodelElement, KeyTypes } from '@aas-core-works/aas-core3.0-typescript/types';
 import { ApplicationComponent } from './visualization-components/ApplicationComponent';
 import { getKeyType } from 'lib/util/KeyTypeUtil';
+import { SubmodelVisualizationProps } from 'app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps';
 
-type BillOfApplicationsDetailProps = {
-    readonly submodel: Submodel;
-};
-
-export function BillOfApplicationsDetail(props: BillOfApplicationsDetailProps) {
-    const submodelElements = props.submodel.submodelElements as ISubmodelElement[];
+export function BillOfApplicationsDetail({ submodel }: SubmodelVisualizationProps) {
+    const submodelElements = submodel.submodelElements as ISubmodelElement[];
     const entryNode = submodelElements.find((el) => getKeyType(el) === KeyTypes.Entity) as Entity;
 
     return <ApplicationComponent entity={entryNode as Entity} />;

--- a/src/app/[locale]/viewer/_components/submodel/carbon-footprint/CarbonFootprintDetail.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/carbon-footprint/CarbonFootprintDetail.tsx
@@ -2,11 +2,11 @@ import { ExpandableDefaultSubmodelDisplay } from 'components/basics/ExpandableNe
 import { CarbonFootprintVisualizations } from './CarbonFootprintVisualizations';
 import { SubmodelVisualizationProps } from 'app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps';
 
-export function CarbonFootprintDetail(props: SubmodelVisualizationProps) {
+export function CarbonFootprintDetail({ submodel }: SubmodelVisualizationProps) {
     return (
         <>
-            <CarbonFootprintVisualizations submodel={props.submodel} />
-            <ExpandableDefaultSubmodelDisplay submodel={props.submodel} />
+            <CarbonFootprintVisualizations submodel={submodel} />
+            <ExpandableDefaultSubmodelDisplay submodel={submodel} />
         </>
     );
 }

--- a/src/app/[locale]/viewer/_components/submodel/carbon-footprint/CarbonFootprintDetail.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/carbon-footprint/CarbonFootprintDetail.tsx
@@ -1,12 +1,8 @@
 import { ExpandableDefaultSubmodelDisplay } from 'components/basics/ExpandableNestedContentWrapper';
-import { Submodel } from '@aas-core-works/aas-core3.0-typescript/types';
 import { CarbonFootprintVisualizations } from './CarbonFootprintVisualizations';
+import { SubmodelVisualizationProps } from 'app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps';
 
-type CarbonFootprintDetailProps = {
-    readonly submodel: Submodel;
-};
-
-export function CarbonFootprintDetail(props: CarbonFootprintDetailProps) {
+export function CarbonFootprintDetail(props: SubmodelVisualizationProps) {
     return (
         <>
             <CarbonFootprintVisualizations submodel={props.submodel} />

--- a/src/app/[locale]/viewer/_components/submodel/carbon-footprint/CarbonFootprintVisualizations.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/carbon-footprint/CarbonFootprintVisualizations.tsx
@@ -11,17 +11,13 @@ import { ProductLifecycle } from './visualization-components/ProductLifecycle';
 import { hasSemanticId } from 'lib/util/SubmodelResolverUtil';
 import { ProductLifecycleStage } from 'lib/enums/ProductLifecycleStage.enum';
 import { StyledDataRow } from 'components/basics/StyledDataRow';
-import {
-    ISubmodelElement,
-    Property,
-    Submodel,
-    SubmodelElementCollection,
-} from '@aas-core-works/aas-core3.0-typescript/types';
+import { ISubmodelElement, Property, SubmodelElementCollection } from '@aas-core-works/aas-core3.0-typescript/types';
+import { SubmodelVisualizationProps } from 'app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps';
 
-export function CarbonFootprintVisualizations(props: { submodel: Submodel }) {
+export function CarbonFootprintVisualizations({ submodel }: SubmodelVisualizationProps) {
     const intl = useIntl();
 
-    const pcfSubmodelElements = props.submodel.submodelElements?.filter((el) =>
+    const pcfSubmodelElements = submodel.submodelElements?.filter((el) =>
         hasSemanticId(
             el,
             SubmodelElementSemanticId.ProductCarbonFootprint,

--- a/src/app/[locale]/viewer/_components/submodel/generic-submodel/GenericSubmodelDetailComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/generic-submodel/GenericSubmodelDetailComponent.tsx
@@ -3,10 +3,10 @@ import { idEquals } from 'lib/util/IdValidationUtil';
 import { submodelElementCustomVisualizationMap } from '../../submodel-elements/SubmodelElementCustomVisualizationMap';
 import { Fragment } from 'react';
 import { GenericSubmodelElementComponent } from '../../submodel-elements/generic-elements/GenericSubmodelElementComponent';
-import { SubmodelDetailComponentProps } from 'app/[locale]/viewer/_components/submodel/SubmodelDetailComponentProps';
+import { SubmodelVisualizationProps } from 'app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps';
 
-export function GenericSubmodelDetailComponent(props: SubmodelDetailComponentProps) {
-    const submodelElements = props.submodel.submodelElements ?? [];
+export function GenericSubmodelDetailComponent({ submodel }: SubmodelVisualizationProps) {
+    const submodelElements = submodel.submodelElements ?? [];
 
     // Entity element always has a line at the bottom, so we don't need an extra line on the following element
     const isEntityElementAbove = (index: number) => submodelElements[index - 1] instanceof Entity;
@@ -30,14 +30,14 @@ export function GenericSubmodelDetailComponent(props: SubmodelDetailComponentPro
                             <CustomSubmodelElementComponent
                                 key={index}
                                 submodelElement={el as SubmodelElementCollection}
-                                submodelId={props.submodel.id}
+                                submodelId={submodel.id}
                                 hasDivider={hasDivider(index)}
                             />
                         ) : (
                             <GenericSubmodelElementComponent
                                 key={index}
                                 submodelElement={el}
-                                submodelId={props.submodel.id}
+                                submodelId={submodel.id}
                                 hasDivider={hasDivider(index)}
                             />
                         )}

--- a/src/app/[locale]/viewer/_components/submodel/hierarchical-structures/HierarchicalStructuresDetail.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/hierarchical-structures/HierarchicalStructuresDetail.tsx
@@ -5,7 +5,6 @@ import {
     KeyTypes,
     Property,
     RelationshipElement,
-    Submodel,
 } from '@aas-core-works/aas-core3.0-typescript/types';
 import { EntityComponent } from '../../submodel-elements/generic-elements/entity-components/EntityComponent';
 import { cloneDeep } from 'lodash';
@@ -17,13 +16,10 @@ import { GenericSubmodelElementComponent } from '../../submodel-elements/generic
 import { InfoOutlined } from '@mui/icons-material';
 import React from 'react';
 import { ArchetypeDetailsDialog } from './ArchetypeDetailsDialog';
+import { SubmodelVisualizationProps } from 'app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps';
 
-type HierarchicalStructuresDetailProps = {
-    readonly submodel: Submodel;
-};
-
-export function HierarchicalStructuresDetail(props: HierarchicalStructuresDetailProps) {
-    const submodelElements = props.submodel.submodelElements as ISubmodelElement[];
+export function HierarchicalStructuresDetail({ submodel }: SubmodelVisualizationProps) {
+    const submodelElements = submodel.submodelElements as ISubmodelElement[];
 
     const isSubmodelFlattened = checkSubmodelsElements(submodelElements);
 
@@ -73,7 +69,7 @@ export function HierarchicalStructuresDetail(props: HierarchicalStructuresDetail
                     <Box sx={{ mt: 2, display: 'flex' }}>
                         <GenericSubmodelElementComponent
                             key={archeTypePropertylElement.idShort}
-                            submodelId={props.submodel.id}
+                            submodelId={submodel.id}
                             submodelElement={archeTypePropertylElement}
                             hasDivider={false}
                         />

--- a/src/app/[locale]/viewer/_components/submodel/reference-counter/ReferenceCounterDetail.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/reference-counter/ReferenceCounterDetail.tsx
@@ -1,14 +1,10 @@
-import { Submodel } from '@aas-core-works/aas-core3.0-typescript/types';
 import { ReferenceCounterVisualizations } from './ReferenceCounterVisualizations';
+import { SubmodelVisualizationProps } from 'app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps';
 
-type ReferenceCounterDetailProps = {
-    readonly submodel: Submodel;
-};
-
-export function ReferenceCounterDetail(props: ReferenceCounterDetailProps) {
+export function ReferenceCounterDetail({ submodel }: SubmodelVisualizationProps) {
     return (
         <>
-            <ReferenceCounterVisualizations submodel={props.submodel} />
+            <ReferenceCounterVisualizations submodel={submodel} />
         </>
     );
 }

--- a/src/app/[locale]/viewer/_components/submodel/reference-counter/ReferenceCounterVisualizations.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/reference-counter/ReferenceCounterVisualizations.tsx
@@ -1,13 +1,13 @@
-import { Submodel } from '@aas-core-works/aas-core3.0-typescript/types';
 import { messages } from 'lib/i18n/localization';
 import { useIntl } from 'react-intl';
 import { encodeBase64 } from 'lib/util/Base64Util';
 import { ArrowForward } from '@mui/icons-material';
+import { SubmodelVisualizationProps } from 'app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps';
 
-export function ReferenceCounterVisualizations(props: { submodel: Submodel }) {
+export function ReferenceCounterVisualizations({ submodel }: SubmodelVisualizationProps) {
     const intl = useIntl();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { value } = (props.submodel.submodelElements?.at(0) as any) ?? [];
+    const { value } = (submodel.submodelElements?.at(0) as any) ?? [];
 
     const elementDict = new Map<string, number>();
     const elementNames: string[] = [];

--- a/src/app/[locale]/viewer/_components/submodel/time-series/TimeSeriesDetail.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/time-series/TimeSeriesDetail.tsx
@@ -1,16 +1,12 @@
 import { ExpandableDefaultSubmodelDisplay } from 'components/basics/ExpandableNestedContentWrapper';
-import { Submodel } from '@aas-core-works/aas-core3.0-typescript/types';
 import { TimeSeriesVisualizations } from './TimeSeriesVisualizations';
+import { SubmodelVisualizationProps } from 'app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps';
 
-type TimeSeriesDetailProps = {
-    readonly submodel: Submodel;
-};
-
-export function TimeSeriesDetail(props: TimeSeriesDetailProps) {
+export function TimeSeriesDetail({ submodel }: SubmodelVisualizationProps) {
     return (
         <>
-            <TimeSeriesVisualizations submodel={props.submodel} />
-            <ExpandableDefaultSubmodelDisplay submodel={props.submodel} />
+            <TimeSeriesVisualizations submodel={submodel} />
+            <ExpandableDefaultSubmodelDisplay submodel={submodel} />
         </>
     );
 }

--- a/src/app/[locale]/viewer/_components/submodel/time-series/TimeSeriesVisualizations.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/time-series/TimeSeriesVisualizations.tsx
@@ -1,15 +1,16 @@
-import { Submodel, SubmodelElementCollection } from '@aas-core-works/aas-core3.0-typescript/types';
+import { SubmodelElementCollection } from '@aas-core-works/aas-core3.0-typescript/types';
 import { SubmodelElementSemanticId } from 'lib/enums/SubmodelElementSemanticId.enum';
 import { InfluxTimeSeries } from './InfluxTimeSeries';
 import { InternalTimeSeries } from 'app/[locale]/viewer/_components/submodel/time-series/InternalTimeSeries';
 import { hasSemanticId } from 'lib/util/SubmodelResolverUtil';
 import { Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
+import { SubmodelVisualizationProps } from 'app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps';
 
-export function TimeSeriesVisualizations(props: { submodel: Submodel }) {
+export function TimeSeriesVisualizations({ submodel }: SubmodelVisualizationProps) {
     const t = useTranslations('submodels.timeSeries');
 
-    const timeSeriesSegments = props.submodel.submodelElements?.find(
+    const timeSeriesSegments = submodel.submodelElements?.find(
         (el) => el.semanticId?.keys[0].value === SubmodelElementSemanticId.TimeSeriesSegments,
     ) as SubmodelElementCollection | undefined;
 

--- a/src/components/basics/ExpandableNestedContentWrapper.tsx
+++ b/src/components/basics/ExpandableNestedContentWrapper.tsx
@@ -5,12 +5,12 @@ import { NestedContentWrapper } from 'components/basics/NestedContentWrapper';
 import { messages } from 'lib/i18n/localization';
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { Submodel } from '@aas-core-works/aas-core3.0-typescript/types';
 import { GenericSubmodelDetailComponent } from 'app/[locale]/viewer/_components/submodel/generic-submodel/GenericSubmodelDetailComponent';
+import { SubmodelVisualizationProps } from 'app/[locale]/viewer/_components/submodel/SubmodelVisualizationProps';
 
-export function ExpandableDefaultSubmodelDisplay(props: { submodel: Submodel }) {
+export function ExpandableDefaultSubmodelDisplay({ submodel }: SubmodelVisualizationProps) {
     const [isExpanded, setIsExpanded] = useState(false);
-    return props.submodel.submodelElements && props.submodel.submodelElements.length ? (
+    return submodel.submodelElements && submodel.submodelElements.length ? (
         <DataRow title="All available data" hasDivider={true}>
             <Box>
                 <Button
@@ -22,12 +22,12 @@ export function ExpandableDefaultSubmodelDisplay(props: { submodel: Submodel }) 
                 >
                     <FormattedMessage
                         {...messages.mnestix.showEntriesButton[isExpanded ? 'hide' : 'show']}
-                        values={{ count: props.submodel.submodelElements.length }}
+                        values={{ count: submodel.submodelElements.length }}
                     />
                 </Button>
                 {isExpanded && (
                     <NestedContentWrapper>
-                        <GenericSubmodelDetailComponent submodel={props.submodel} />
+                        <GenericSubmodelDetailComponent submodel={submodel} />
                     </NestedContentWrapper>
                 )}
             </Box>


### PR DESCRIPTION
# Description

The interface for custom submodel visualizations should be standartized and extendable in the future.
With the approach in this PR we use one type (`SubmodelVisualizationProps`) in every visualization we have for now.
If we need to add a variable to the props in the future, we would be backwards compatible, as the components would just ignore the new properties.

Fixes # (MNES-1422)

## Type of change

Please delete options that are not relevant.

-   [x] Minor change (non-breaking change, e.g. documentation adaption)

# Checklist:

-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
