### PR TITLE
allow generic translations in LocalizedError.ts

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,7 +1,7 @@
 import en from './locale/en.json';
 import userPluginEn from './user-plugins/locale/en.json';
 
-type Messages = typeof en & userPluginEn;
+type Messages = typeof en & typeof userPluginEn;
 
 declare global {
     interface Window {
@@ -10,7 +10,7 @@ declare global {
         };
     }
 
-    // Use type safe message keys with `next-intl`, "no usages" is intended.
+    // Use type safe message keys with `next-intl`; intl uses this, do not delete
     interface IntlMessages extends Messages {}
 }
 

--- a/src/lib/hooks/UseShowError.tsx
+++ b/src/lib/hooks/UseShowError.tsx
@@ -6,20 +6,20 @@ import { ApiResponseWrapperError } from 'lib/util/apiResponseWrapper/apiResponse
 import { useTranslations } from 'next-intl';
 
 export function useShowError() {
-    const t = useTranslations('errors');
+    const t = useTranslations();
     const notificationSpawner = useNotificationSpawner();
 
     function showNotFoundError(notificationSpawner: NotificationSpawner) {
         notificationSpawner.spawn({
-            message: t('not-found'),
+            message: t('errors.not-found'),
             severity: 'error',
         });
     }
 
     function showUnauthorizedError(notificationSpawner: NotificationSpawner) {
         notificationSpawner.spawn({
-            title: t('unauthorized-error.title'),
-            message: t('unauthorized-error.content'),
+            title: t('errors.unauthorized-error.title'),
+            message: t('errors.unauthorized-error.content'),
             severity: 'error',
         });
     }
@@ -48,7 +48,7 @@ export function useShowError() {
                         notificationSpawner.spawn({
                             message: (
                                 <>
-                                    {t('unexpected-error')}
+                                    {t('errors.unexpected-error')}
                                     <Typography variant="body2" sx={{ mt: 1, opacity: 0.7 }}>
                                         {e.status}: &quot;{e.statusText}&quot;
                                     </Typography>
@@ -74,7 +74,7 @@ export function useShowError() {
                         notificationSpawner.spawn({
                             message: (
                                 <>
-                                    {t('unexpected-error')}
+                                    {t('errors.unexpected-error')}
                                     <Typography variant="body2" sx={{ mt: 1, opacity: 0.7 }}>
                                         {e.errorCode}: &quot;{e.message}&quot;
                                     </Typography>
@@ -87,7 +87,7 @@ export function useShowError() {
             }
 
             notificationSpawner.spawn({
-                message: t('unexpected-error'),
+                message: t('errors.unexpected-error'),
                 severity: 'error',
             });
         },

--- a/src/lib/util/LocalizedError.ts
+++ b/src/lib/util/LocalizedError.ts
@@ -1,7 +1,18 @@
-export class LocalizedError extends Error {
-    descriptor: string;
+type Paths<Schema, Path extends string = ''> = Schema extends string
+    ? Path
+    : Schema extends object
+        ? {
+            [K in keyof Schema & string]: Paths<
+                Schema[K],
+                `${Path}${Path extends '' ? '' : '.'}${K}`
+            >;
+        }[keyof Schema & string]
+        : never;
 
-    constructor(message: string) {
+export class LocalizedError extends Error {
+    descriptor: Paths<IntlMessages>;
+
+    constructor(message: Paths<IntlMessages>) {
         const trueProto = new.target.prototype;
         super();
         Object.setPrototypeOf(this, trueProto);


### PR DESCRIPTION
# Description

This allows LocalizedError to use any message key as their descriptor.

This needs to be adjusted in every usecase of LocalizedError ;/