### PR TITLE
chore(Dependabot): Add dependabot conf 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    target-branch: dev
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+      time: '07:00'
+      timezone: 'Europe/Berlin'
+    groups:
+      yarn-patch:
+        update-types: ['patch']
+      yarn-minor:
+        update-types: ['minor']
+      yarn-major:
+        update-types: ['major']
+  - package-ecosystem: 'docker'
+    target-branch: dev
+    directory: '/'
+    groups:
+      docker-all:
+        patterns:
+          - '*'
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker-compose
+    target-branch: dev
+    directory: '/'
+    groups:
+      compose-all:
+        patterns:
+          - '*'
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    target-branch: dev
+    directory: '/'
+    groups:
+      actions-all:
+        patterns:
+          - '*'
+    schedule:
+      interval: weekly

--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -14,5 +14,5 @@ jobs:
   publish-wiki:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: Andrew-Chen-Wang/github-wiki-action@v4


### PR DESCRIPTION
# Description

Add a dependabot configuration.
I did some grouping so there won't be too many PRs for version updates. The PRs could be merged on monday in a maintenance work.

There are too many updates to be done in one issue/pr so I am going to create subtasks and will activate automatic PRs when those dependencies are updated.

https://github.com/sirchnik-xitaso/mnestix-browser/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen+author%3Aapp%2Fdependabot

## Type of change

-   [x] Minor change (non-breaking change, e.g. documentation adaption)