### PR TITLE
docs(dev-mode): Remove the dev from the keycloak readme and from the yarn scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,12 +105,12 @@
     "docker:dev": "docker compose -f compose.yml -f docker-compose/compose.dev.yml --profile basyx --profile backend --profile frontend up",
     "docker:backend": "docker compose -f compose.yml -f docker-compose/compose.dev.yml --profile basyx --profile backend up",
     "docker:prod": "docker compose up",
-    "docker:test": "docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests up -d --build && docker compose -f compose.yml -f docker-compose/compose.test.yml attach cypress-test",
-    "docker:stop": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.test.yml kill",
-    "docker:down": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.test.yml down",
-    "docker:prune": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.test.yml -f docker-compose/compose.keycloak.yml down -v && docker network prune && docker network rm mnestix-network",
-    "docker:keycloak": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.keycloak.yml up",
-    "docker:azure": "docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.azure_ad.yml up"
+    "docker:test": "docker compose -f compose.yml --profile tests up -d --build && docker compose -f compose.yml -f docker-compose/compose.test.yml attach cypress-test",
+    "docker:stop": "docker compose -f compose.yml -f docker-compose/compose.test.yml kill",
+    "docker:down": "docker compose -f compose.yml -f docker-compose/compose.test.yml down",
+    "docker:prune": "docker compose -f compose.yml  -f docker-compose/compose.test.yml -f docker-compose/compose.keycloak.yml down -v && docker network prune && docker network rm mnestix-network",
+    "docker:keycloak": "docker compose -f compose.yml -f docker-compose/compose.keycloak.yml up",
+    "docker:azure": "docker compose -f compose.yml -f docker-compose/compose.azure_ad.yml up"
   },
   "browserslist": {
     "production": [

--- a/wiki/Keycloak-Configuration.md
+++ b/wiki/Keycloak-Configuration.md
@@ -8,7 +8,7 @@
 To start Mnestix along with Keycloak as the authorization server, use one of the following commands:
 
 ```sh
-docker compose -f compose.yml -f docker-compose/compose.dev.yml -f docker-compose/compose.keycloak.yml up -d
+docker compose -f compose.yml -f docker-compose/compose.keycloak.yml up -d
 ```
 
 or, alternatively:


### PR DESCRIPTION
# Description

Remove the dev port openings and live compiling from the docker scripts.

Fixes # (MNES-1519)

## Type of change

-   [x] Minor change (non-breaking change, e.g. documentation adaption)