### PR TITLE
HOT-FIX: fix(EntityTreeItem) - change window.open target to '_top' for assetId

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,7 +15,7 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: mnestix-browser
   # Update the version manually
-  IMAGE_TAG_VERSION: 1.4.1
+  IMAGE_TAG_VERSION: 1.4.2
 
 jobs:
   build-browser-image:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mnestix-browser",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "license": "MIT",
   "devDependencies": {

--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/entity-components/EntityTreeItem.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/entity-components/EntityTreeItem.tsx
@@ -50,7 +50,7 @@ const CustomContent = React.forwardRef(function CustomContent(props: CustomTreeI
 
             const { isSuccess, result: aasIds } = await performDiscoveryAasSearch(assetId);
             if (isSuccess && aasIds.length === 0) {
-                window.open(assetId, '_blank');
+                window.open(assetId, '_top');
             } else {
                 navigate.push('/asset?assetId=' + encodeURIComponent(assetId));
             }

--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/entity-components/EntityTreeItem.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/entity-components/EntityTreeItem.tsx
@@ -49,8 +49,13 @@ const CustomContent = React.forwardRef(function CustomContent(props: CustomTreeI
             // if not, just navigate to the specified URL which might lead anywhere.
 
             const { isSuccess, result: aasIds } = await performDiscoveryAasSearch(assetId);
-            if (isSuccess && aasIds.length === 0) {
-                window.open(assetId, '_top');
+            if (!isSuccess || (isSuccess && aasIds.length === 0)) {
+                const popup = window.open(''); // Try to open a new tab
+                if (popup) { // if not null -> new tab was opened
+                    popup.location.href = assetId;    
+                } else { // popup was blocked open in same tab
+                    navigate.push(assetId);
+                }
             } else {
                 navigate.push('/asset?assetId=' + encodeURIComponent(assetId));
             }


### PR DESCRIPTION
# Description

**Fixes an issue where assets from the Bill of Materials (BoM) wouldn't open in Safari on iOS.**

This pull request includes a small change to the `EntityTreeItem.tsx` file. The change modifies the behavior of the `window.open` function to open the URL in the same tab instead of a new tab.

## TESTING REQUIRED:

### iOS (Safari was the issue, so ensure thorough testing)
-   [ ] Safari (latest iOS version)

### Android
-   [ ] Google Chrome
-   [ ] Samsung Internet Browser
-   [ ] Mozilla Firefox

### Desktop Browsers

-   [ ] Google Chrome (Windows, macOS, Linux)
-   [ ] Mozilla Firefox
-   [ ] Microsoft Edge (Windows)
-   [ ] Safari (macOS)

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [x] My changes contain no console logs
