### PR TITLE
fix(setup): log error when submodel registry is not reachable

### DIFF
--- a/src/lib/services/searchUtilActions/SubmodelSearcher.ts
+++ b/src/lib/services/searchUtilActions/SubmodelSearcher.ts
@@ -53,13 +53,19 @@ export class SubmodelSearcher {
 
     async getSubmodelDescriptorById(submodelId: string): Promise<ApiResponseWrapper<SubmodelDescriptor>> {
         const defaultUrl = process.env.SUBMODEL_REGISTRY_API_URL;
-        if (!defaultUrl)
+        if (!defaultUrl) {
             return wrapErrorCode(ApiResultStatus.INTERNAL_SERVER_ERROR, 'No default Submodel registry defined');
+        }
         const response = await this.getSubmodelRegistryClient(defaultUrl).getSubmodelDescriptorById(submodelId);
         if (response.isSuccess) return response;
         else {
+            if (response.errorCode === ApiResultStatus.UNKNOWN_ERROR) {
+                console.error(
+                    `Configuration Error: Default Submodel registry ${process.env.SUBMODEL_REGISTRY_API_URL} is not reachable.`,
+                );
+            }
             if (response.errorCode === ApiResultStatus.NOT_FOUND) {
-                console.error(response.message);
+                console.warn(response.message);
             }
             return wrapErrorCode<SubmodelDescriptor>(ApiResultStatus.NOT_FOUND, 'Submodel not found');
         }


### PR DESCRIPTION
# Description

MNC-106

As Meli pointed out the problem occurs when the submodel registries are not reachable. The best thing we can do for this instance is logging the error.
Throwing the error would be a breaking change, I think because then it does not at all anymore.

Further a connectifity check could be introduced but not in this task.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
