### PR TITLE
fix(theming): remove logo mounting in compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -37,7 +37,7 @@ services:
       - mnestix-network
     volumes:
       - mnestix-database:/app/prisma/database
-      - ./data/logo.jpg:/app/public/logo
+      - ./docker-compose/data/logo.svg:/app/public/logo
 
   mnestix-api:
     image: mnestix/mnestix-api:1.3.2

--- a/compose.yml
+++ b/compose.yml
@@ -37,7 +37,6 @@ services:
       - mnestix-network
     volumes:
       - mnestix-database:/app/prisma/database
-      - ./docker-compose/data/logo.svg:/app/public/logo
 
   mnestix-api:
     image: mnestix/mnestix-api:1.3.2

--- a/wiki/Mnestix-Configuration-Settings.md
+++ b/wiki/Mnestix-Configuration-Settings.md
@@ -3,7 +3,7 @@
 Mnestix provides the following configuration options. You can adapt the values in your docker compose file.
 
 | Name                                  | Default value               | Description                                                                                                                                                                                                                        | required |
-|---------------------------------------|-----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| ------------------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | `DISCOVERY_API_URL`                   |                             | Address of the Discovery Service to find an AAS for an Asset                                                                                                                                                                       | required |
 | `REGISTRY_API_URL`                    |                             | Address of the AAS Registry Service to retrieve the related descriptor for an AAS                                                                                                                                                  | optional |
 | `SUBMODEL_REGISTRY_API_URL`           |                             | Address of the Submodel Registry Service to retrieve the related descriptor for a Submodel                                                                                                                                         | optional |
@@ -32,30 +32,28 @@ Mnestix provides the following configuration options. You can adapt the values i
 
 ### How to set a custom logo
 
-There are multiple ways to set a logo. You can choose between either of the following options depending on your preference:
+There are multiple ways to set a logo. You can choose between either of the following options depending on your
+preference:
 
 #### Option 1: Mount a logo
 
-First you need to mount your logo to the container by adding it to the docker compose file. 
+First you need to mount your logo to the container by adding it to the docker compose file: 
 
 ```yaml
-environment:
-  - THEME_LOGO_MIME_TYPE: 'image/svg+xml'
----
 volumes:
-  - /path/to/my/logo.svg:/app/public/logo
+    - /path/to/my/logo.svg:/app/public/logo
 ```
 
 When using the provided [`compose.yaml` File](https://github.com/eclipse-mnestix/mnestix-browser/blob/main/compose.yml)
-you can just place your logo in the
-[`data` folder](https://github.com/eclipse-mnestix/mnestix-browser/tree/main/docker-compose/data/).
+you can place your logo in the [
+`data` folder](https://github.com/eclipse-mnestix/mnestix-browser/tree/main/docker-compose/data/).
 
 You also have to set the mime type correctly in order for the browser to parse your image correctly.
 E.g. for an SVG image, set the mime type to `image/svg+xml`:
 
 ```yaml
 environment:
-  THEME_LOGO_MIME_TYPE: 'image/svg+xml'
+    THEME_LOGO_MIME_TYPE: 'image/svg+xml'
 ```
 
 Only image mime types are allowed.
@@ -63,12 +61,12 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Comm
 
 #### Option 2: Base64 encoded logo
 
-This version overwrites the previous setting. 
+This version overwrites the previous setting.
 To use this, provide a base64 encoded image in the environment variable:
 
 ```yaml
 environment:
-  THEME_BASE64_LOGO: '<<BASE64_ENCODED_IMAGE>>'
+    THEME_BASE64_LOGO: '<<BASE64_ENCODED_IMAGE>>'
 ```
 
 #### Option 3: Link to a hosted logo
@@ -78,7 +76,7 @@ To use this just set an environment variable to a link hosted that is publicly a
 
 ```yaml
 environment:
-  THEME_LOGO_URL: https://xitaso.com/wp-content/uploads/XITASO-Logo-quer.svg
+    THEME_LOGO_URL: https://xitaso.com/wp-content/uploads/XITASO-Logo-quer.svg
 ```
 
 ### Using Azure Entra ID


### PR DESCRIPTION
# Description

Removes the path to the logo in the compose.yml as there is no default logo in the data folder anymore. 

## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [x] My changes contain no console logs
