### PR TITLE
fix(IdGenerationSettings): Temporary Bugfix for BaSyx PATCH 404 error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,11 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "eslint.workingDirectories": ["src"],
-    "github.copilot.chat.codeGeneration.useInstructionFiles": true
+    "github.copilot.chat.codeGeneration.useInstructionFiles": true,
+    "i18n-ally.localesPaths": [
+        "src/i18n",
+        "src/locale",
+        "src/lib/i18n",
+        "src/user-plugins/locale"
+    ]
 }

--- a/src/lib/api/configuration-shell-api/configurationShellApi.ts
+++ b/src/lib/api/configuration-shell-api/configurationShellApi.ts
@@ -1,6 +1,7 @@
 import { Submodel } from '@aas-core-works/aas-core3.0-typescript/types';
 import { IConfigurationShellApi } from 'lib/api/configuration-shell-api/configurationShellApiInterface';
 import { ApiResponseWrapper, wrapErrorCode, wrapSuccess } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
+import { ApiResultStatus } from 'lib/util/apiResponseWrapper/apiResultStatus';
 
 export class ConfigurationShellApi implements IConfigurationShellApi {
     private constructor(
@@ -47,10 +48,14 @@ export class ConfigurationShellApi implements IConfigurationShellApi {
             dynamicPart: string;
         },
     ) : Promise<ApiResponseWrapper<void>> {
+        // DANGER DANGER
+        // THIS IS JUST A TEMPORARY FIX TILL BASYX FIXES THE PATCH CALL TO NOT GIVE 404 WHEN THERE IS NO CHANGE
+        // BUG IS IN BASYX 2.0.0-milestone5
+        // DANGER DANGER
         let response = await this.putSingleSettingValue(`${idShort}.Prefix`, values.prefix, 'idGeneration');
-        if (!response.isSuccess) { return wrapErrorCode(response.errorCode, response.message); }
+        if (!response.isSuccess && response.errorCode != ApiResultStatus.NOT_FOUND) { return wrapErrorCode(response.errorCode, response.message); }
         response = await this.putSingleSettingValue(`${idShort}.DynamicPart`, values.dynamicPart, 'idGeneration');
-        if (!response.isSuccess) { return wrapErrorCode(response.errorCode, response.message); }
+        if (!response.isSuccess && response.errorCode != ApiResultStatus.NOT_FOUND) { return wrapErrorCode(response.errorCode, response.message); }
         
         return wrapSuccess(response.result);
     }


### PR DESCRIPTION
# Description

BaSyx is giving a 404 if we use a PATCH Call in the ID Generation Settings and the value has not changed. To fix this for the user till BaSyx fixes this problem I excluded the 404 for this specific wrap to eliminate the error. I already made a ticket to reverse this change as soon as BaSyx will fix this.

## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
