### PR TITLE
fix(rbac-ui) app crashing when last id item gets removed

### DIFF
--- a/src/app/[locale]/settings/_components/role-settings/RuleForm.spec.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleForm.spec.tsx
@@ -148,5 +148,16 @@ describe('RuleForm', () => {
             });
             expect(screen.queryByTestId('input-aas-environment-aasIds-1')).not.toBeInTheDocument();
         });
+
+        it('sets wildcard to true when last input element is removed', async () => {
+            render(<RuleForm {...defaultProps} />);
+            const removeButton = screen.getByTestId('remove-aas-environment-aasIds-0');
+            await act(async () => {
+                fireEvent.click(removeButton);
+            });
+
+            const wildcardCheckbox = screen.getByTestId('checkbox-aas-environment-aasIds').querySelector('input');
+            expect(wildcardCheckbox).toBeChecked();
+        });
     });
 });

--- a/src/app/[locale]/settings/_components/role-settings/target-information/WildcardOrStringArrayInput.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/target-information/WildcardOrStringArrayInput.tsx
@@ -78,7 +78,11 @@ export const WildcardOrStringArrayInput = (props: WildcardOrStringArrayInputProp
                                         <RemoveCircleOutlineIcon
                                             data-testid={`remove-${props.type}-${props.rule}-${idx}`}
                                             onClick={() => {
-                                                remove(idx);
+                                                if (idx === 0) {
+                                                    wildcardValueChanged(true);
+                                                } else {
+                                                    remove(idx);
+                                                }
                                             }}
                                         />
                                     </IconButton>


### PR DESCRIPTION
# Description

When the last id item gets removed, the wildcard is selected 

## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix or my feature works
-   [x] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
