### PR TITLE
fix(TransferService): Add TransferServiceConfig type

### DIFF
--- a/src/lib/services/transfer-service/TransferService.ts
+++ b/src/lib/services/transfer-service/TransferService.ts
@@ -17,7 +17,7 @@ import {
     Submodel,
     SubmodelElementCollection,
 } from '@aas-core-works/aas-core3.0-typescript/types';
-import { AttachmentDetails, TransferAas, TransferResult, TransferSubmodel } from 'lib/types/TransferServiceData';
+import { AttachmentDetails, TransferAas, TransferResult, TransferServiceConfig, TransferSubmodel } from 'lib/types/TransferServiceData';
 import { getKeyType } from 'lib/util/KeyTypeUtil';
 import { generateRandomId } from 'lib/util/RandomUtils';
 import {
@@ -54,45 +54,38 @@ export class TransferService {
     ) {}
 
     static create(
-        targetAasRepositoryBaseUrl: string,
-        sourceAasRepositoryBaseUrl: string,
-        targetSubmodelRepositoryBaseUrl: string,
-        sourceSubmodelRepositoryBaseUrl: string,
-        targetAasDiscoveryBaseUrl?: string,
-        targetAasRegistryBaseUrl?: string,
-        targetSubmodelRegistryBaseUrl?: string,
-        apikey?: string,
+        config: TransferServiceConfig,
     ): TransferService {
         const targetAasRepositoryClient = AssetAdministrationShellRepositoryApi.create(
-            targetAasRepositoryBaseUrl,
+            config.targetAasRepoUrl,
             mnestixFetch(),
         );
 
         const sourceAasRepositoryClient = AssetAdministrationShellRepositoryApi.create(
-            sourceAasRepositoryBaseUrl,
+            config.sourceAasRepoUrl,
             mnestixFetch(),
         );
 
         const targetSubmodelRepositoryClient = SubmodelRepositoryApi.create(
-            targetSubmodelRepositoryBaseUrl,
+            config.targetSubmodelRepoUrl,
             mnestixFetch(),
         );
 
         const sourceSubmodelRepositoryClient = SubmodelRepositoryApi.create(
-            sourceSubmodelRepositoryBaseUrl,
+            config.sourceSubmodelRepoUrl,
             mnestixFetch(),
         );
 
-        const targetAasDiscoveryClient = targetAasDiscoveryBaseUrl
-            ? DiscoveryServiceApi.create(targetAasDiscoveryBaseUrl, mnestixFetch())
+        const targetAasDiscoveryClient = config.targetDiscoveryUrl
+            ? DiscoveryServiceApi.create(config.targetDiscoveryUrl, mnestixFetch())
             : undefined;
 
-        const targetAasRegistryClient = targetAasRegistryBaseUrl
-            ? RegistryServiceApi.create(targetAasRegistryBaseUrl, mnestixFetch())
+        const targetAasRegistryClient = config.targetAasRegistryUrl
+            ? RegistryServiceApi.create(config.targetAasRegistryUrl, mnestixFetch())
             : undefined;
 
-        const targetSubmodelRegistryClient = targetSubmodelRegistryBaseUrl
-            ? SubmodelRegistryServiceApi.create(targetSubmodelRegistryBaseUrl, mnestixFetch())
+        const targetSubmodelRegistryClient = config.targetSubmodelRegistryUrl
+            ? SubmodelRegistryServiceApi.create(config.targetSubmodelRegistryUrl, mnestixFetch())
             : undefined;
 
         return new TransferService(
@@ -103,7 +96,7 @@ export class TransferService {
             targetAasDiscoveryClient,
             targetAasRegistryClient,
             targetSubmodelRegistryClient,
-            apikey,
+            config.apikey,
         );
     }
 
@@ -244,7 +237,7 @@ export class TransferService {
     private async postAasToRepository(aas: AssetAdministrationShell, apikey?: string): Promise<TransferResult> {
         const response = await this.targetAasRepositoryClient.postAssetAdministrationShell(aas, {
             headers: {
-                Apikey: apikey,
+                ApiKey: apikey,
             },
         });
         if (response.isSuccess) {
@@ -271,7 +264,7 @@ export class TransferService {
     private async postSubmodelToRepository(submodel: Submodel, apikey?: string): Promise<TransferResult> {
         const response = await this.targetSubmodelRepositoryClient.postSubmodel(submodel, {
             headers: {
-                Apikey: apikey,
+                ApiKey: apikey,
             },
         });
         if (response.isSuccess) {
@@ -323,7 +316,7 @@ export class TransferService {
             fileName,
             {
                 headers: {
-                    Apikey: apikey,
+                    ApiKey: apikey,
                 },
             },
         );
@@ -387,7 +380,7 @@ export class TransferService {
             attachment,
             {
                 headers: {
-                    Apikey: apikey,
+                    ApiKey: apikey,
                 },
             },
         );

--- a/src/lib/services/transfer-service/transferActions.ts
+++ b/src/lib/services/transfer-service/transferActions.ts
@@ -5,14 +5,16 @@ import { TransferDto, TransferResult } from 'lib/types/TransferServiceData';
 
 export async function transferAasWithSubmodels(transferDto: TransferDto): Promise<TransferResult[]> {
     const transfer = TransferService.create(
-        transferDto.targetAasRepositoryBaseUrl,
-        transferDto.targetSubmodelRepositoryBaseUrl,
-        transferDto.sourceAasRepositoryBaseUrl,
-        transferDto.sourceSubmodelRepositoryBaseUrl,
-        transferDto.targetDiscoveryBaseUrl,
-        transferDto.targetAasRegistryBaseUrl,
-        transferDto.targetSubmodelRegistryBaseUrl,
-        transferDto.apikey,
+        {
+            targetAasRepoUrl: transferDto.targetAasRepositoryBaseUrl,
+            sourceAasRepoUrl: transferDto.sourceAasRepositoryBaseUrl,
+            targetSubmodelRepoUrl: transferDto.targetSubmodelRepositoryBaseUrl,
+            sourceSubmodelRepoUrl: transferDto.sourceSubmodelRepositoryBaseUrl,
+            targetDiscoveryUrl: transferDto.targetDiscoveryBaseUrl,
+            targetAasRegistryUrl: transferDto.targetAasRegistryBaseUrl,
+            targetSubmodelRegistryUrl: transferDto.targetSubmodelRegistryBaseUrl,
+            apikey: transferDto.apikey,
+        }
     );
     return transfer.transferAasWithSubmodels(transferDto.aas, transferDto.submodels);
 }

--- a/src/lib/types/TransferServiceData.ts
+++ b/src/lib/types/TransferServiceData.ts
@@ -41,3 +41,14 @@ export type AttachmentDetails = {
     fileName: string | null;
     file?: Blob;
 };
+
+export type TransferServiceConfig = {
+    targetAasRepoUrl: string;
+    sourceAasRepoUrl: string;
+    targetSubmodelRepoUrl: string;
+    sourceSubmodelRepoUrl: string;
+    targetDiscoveryUrl?: string;
+    targetAasRegistryUrl?: string;
+    targetSubmodelRegistryUrl?: string;
+    apikey?: string;
+}


### PR DESCRIPTION
# Description

This pull request refactors the `TransferService` class to use a configuration object for its initialization, and corrects the API key header name.

Fixes # (Issue)

## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
