### PR TITLE
fix(rbac): add error handling for unique idShort requirement

### DIFF
--- a/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.tsx
@@ -34,9 +34,15 @@ export const CreateRuleDialog = (props: RoleDialogProps) => {
                 severity: 'success',
             });
             onCloseDialog(true);
-        } else {
-            showError(response.message);
+            return;
         }
+        if (response.errorCode === 'CONFLICT') {
+            return notificationSpawner.spawn({
+                message: t('errors.uniqueIdShort'),
+                severity: 'error',
+            });
+        }
+        showError(response.message);
     }
 
     const onCloseDialog = (reload: boolean) => {

--- a/src/app/[locale]/settings/_components/role-settings/RuleDialog.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleDialog.tsx
@@ -33,9 +33,15 @@ export const RuleDialog = (props: RuleDialogProps) => {
                 severity: 'success',
             });
             onCloseDialog(true);
-        } else {
-            showError(response.message);
+            return;
         }
+        if (response.errorCode === 'CONFLICT') {
+            return notificationSpawner.spawn({
+                message: t('errors.uniqueIdShort'),
+                severity: 'error',
+            });
+        }
+        showError(response.message);
     }
 
     const onCloseDialog = (reload: boolean) => {

--- a/src/lib/services/rbac-service/RbacRulesService.ts
+++ b/src/lib/services/rbac-service/RbacRulesService.ts
@@ -16,7 +16,7 @@ const SEC_SUB_ID = 'SecuritySubmodel';
 export class RbacRulesService {
     private constructor(
         private readonly securitySubmodelRepositoryClient: ISubmodelRepositoryApi,
-        private readonly log: typeof logger = logger
+        private readonly log: typeof logger = logger,
     ) {}
 
     static createService(log?: typeof logger): RbacRulesService {
@@ -33,9 +33,14 @@ export class RbacRulesService {
         return new RbacRulesService(subRepoApi);
     }
 
-
     async createRule(newRule: Omit<BaSyxRbacRule, 'idShort'>): Promise<ApiResponseWrapper<BaSyxRbacRule>> {
         const newIdShort = ruleToIdShort(newRule);
+        if (!(await this.isIdShortUnique(newIdShort))) {
+            return wrapErrorCode(
+                ApiResultStatus.CONFLICT,
+                'IdShort already exists. Role name, action and target type must be unique.',
+            );
+        }
         const ruleSubmodelElement = ruleToSubmodelElement(newIdShort, newRule);
 
         const response = await this.securitySubmodelRepositoryClient.postSubmodelElement(
@@ -43,31 +48,19 @@ export class RbacRulesService {
             ruleSubmodelElement,
         );
         if (!response.isSuccess) {
-            logResponseWarn(
-                this.log,
-                'createRule',
-                'Failed to create Rule',
-                response,
-                {
-                    Rule: newRule.role,
-                    IdShort: newIdShort,
-                },
-            );
+            logResponseWarn(this.log, 'createRule', 'Failed to create Rule', response, {
+                Rule: newRule.role,
+                IdShort: newIdShort,
+            });
             return wrapErrorCode(
                 ApiResultStatus.INTERNAL_SERVER_ERROR,
                 'Failed to create Rule in SecuritySubmodel Repo',
             );
         }
-        logResponseDebug(
-                        this.log,
-                        'createRule',
-                        'Rule created',
-                        response,
-                        {
-                            Rule: newRule.role,
-                            IdShort: newIdShort,
-                        },
-                    );
+        logResponseDebug(this.log, 'createRule', 'Rule created', response, {
+            Rule: newRule.role,
+            IdShort: newIdShort,
+        });
         return wrapSuccess(submodelToRule(response.result));
     }
 
@@ -104,7 +97,10 @@ export class RbacRulesService {
                 }) ?? [];
         const roles = parsedRoles.filter((r): r is BaSyxRbacRule => !('error' in r));
         const warnings = parsedRoles.filter((r): r is { error: string[] } => 'error' in r).map((e) => e.error);
-        logResponseDebug(this.log, 'getRules', 'Fetched RBAC rules', response, { Roles: roles.length, Warnings: warnings });
+        logResponseDebug(this.log, 'getRules', 'Fetched RBAC rules', response, {
+            Roles: roles.length,
+            Warnings: warnings,
+        });
         return wrapSuccess({ roles: roles, warnings: warnings });
     }
 
@@ -112,36 +108,32 @@ export class RbacRulesService {
      * Deletes a rule and creates a new rule with new idShort
      */
     async deleteAndCreate(idShort: string, newRule: BaSyxRbacRule): Promise<ApiResponseWrapper<BaSyxRbacRule>> {
+        const newIdShort = ruleToIdShort(newRule);
+
+        if (idShort !== newIdShort && !(await this.isIdShortUnique(newIdShort))) {
+            return wrapErrorCode(
+                ApiResultStatus.CONFLICT,
+                'IdShort already exists. Role name, action and target type must be unique.',
+            );
+        }
+
         const deleteRes = await this.securitySubmodelRepositoryClient.deleteSubmodelElementByPath(SEC_SUB_ID, idShort);
         if (!deleteRes.isSuccess) {
             if (deleteRes.errorCode === ApiResultStatus.NOT_FOUND) {
-                logResponseInfo(
-                    this.log,
-                    'deleteAndCreate',
-                    'Failed to delete Rule',
-                    deleteRes,
-                    {
-                        Rule: idShort,
-                    },
-                );
+                logResponseInfo(this.log, 'deleteAndCreate', 'Failed to delete Rule', deleteRes, {
+                    Rule: idShort,
+                });
                 return wrapErrorCode(ApiResultStatus.NOT_FOUND, 'Rule not found in SecuritySubmodel. Try reloading.');
             }
-            logResponseWarn(
-                this.log,
-                'deleteAndCreate',
-                'Failed to delete Rule',
-                deleteRes,
-                {
-                    Rule: idShort,
-                },
-            );
+            logResponseWarn(this.log, 'deleteAndCreate', 'Failed to delete Rule', deleteRes, {
+                Rule: idShort,
+            });
             return wrapErrorCode(
                 ApiResultStatus.INTERNAL_SERVER_ERROR,
                 'Failed to delete Rule in SecuritySubmodel Repo due to unknown error.',
             );
         }
 
-        const newIdShort = ruleToIdShort(newRule);
         const ruleSubmodelElement = ruleToSubmodelElement(newIdShort, newRule);
 
         const response = await this.securitySubmodelRepositoryClient.postSubmodelElement(
@@ -149,28 +141,16 @@ export class RbacRulesService {
             ruleSubmodelElement,
         );
         if (!response.isSuccess) {
-            logResponseWarn(
-                this.log,
-                'createRule',
-                'Failed to create Rule',
-                response,
-                {
-                    Rule: newRule.role,
-                    IdShort: newIdShort,
-                },
-            );
-            return wrapErrorCode(ApiResultStatus.INTERNAL_SERVER_ERROR, 'Failed to set Rule in SecuritySubmodel Repo');
-        }
-        logResponseDebug(
-            this.log,
-            'createRule',
-            'Rule created',
-            response,
-            {
+            logResponseWarn(this.log, 'createRule', 'Failed to create Rule', response, {
                 Rule: newRule.role,
                 IdShort: newIdShort,
-            },
-        );
+            });
+            return wrapErrorCode(ApiResultStatus.INTERNAL_SERVER_ERROR, 'Failed to set Rule in SecuritySubmodel Repo');
+        }
+        logResponseDebug(this.log, 'createRule', 'Rule created', response, {
+            Rule: newRule.role,
+            IdShort: newIdShort,
+        });
         return wrapSuccess(submodelToRule(response.result));
     }
 
@@ -178,10 +158,7 @@ export class RbacRulesService {
      * Deletes a rule
      */
     async delete(idShort: string): Promise<ApiResponseWrapper<undefined>> {
-        const response = await this.securitySubmodelRepositoryClient.deleteSubmodelElementByPath(
-            SEC_SUB_ID,
-            idShort,
-        );
+        const response = await this.securitySubmodelRepositoryClient.deleteSubmodelElementByPath(SEC_SUB_ID, idShort);
         if (response.isSuccess) {
             logResponseDebug(this.log, 'delete', 'Rule deleted', response, { Rule: idShort });
             return wrapSuccess(undefined);
@@ -193,5 +170,13 @@ export class RbacRulesService {
         logResponseWarn(this.log, 'delete', 'Failed to delete Rule', response, { Rule: idShort });
         return wrapErrorCode(ApiResultStatus.INTERNAL_SERVER_ERROR, 'Failed to set Rule in SecuritySubmodel Repo');
     }
-}
 
+    private async isIdShortUnique(idShort: string) {
+        const rules = await this.getRules();
+        if (!rules.isSuccess) {
+            return false;
+        }
+
+        return !rules.result.roles.find((e) => e.idShort === idShort);
+    }
+}

--- a/src/lib/services/rbac-service/RbacRulesService.ts
+++ b/src/lib/services/rbac-service/RbacRulesService.ts
@@ -107,7 +107,10 @@ export class RbacRulesService {
     /**
      * Deletes a rule and creates a new rule with new idShort
      */
-    async deleteAndCreate(idShort: string, newRule: BaSyxRbacRule): Promise<ApiResponseWrapper<BaSyxRbacRule>> {
+    async deleteAndCreate(
+        idShort: string,
+        newRule: Omit<BaSyxRbacRule, 'idShort'>,
+    ): Promise<ApiResponseWrapper<BaSyxRbacRule>> {
         const newIdShort = ruleToIdShort(newRule);
 
         if (idShort !== newIdShort && !(await this.isIdShortUnique(newIdShort))) {

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -282,10 +282,10 @@
     },
     "settings": {
       "actions": {
-          "cancel": "Abbrechen",
-          "editButton": "Alle bearbeiten",
-          "resetButton": "Auf Default zurücksetzen",
-          "saveButton": "Alle speichern"
+        "cancel": "Abbrechen",
+        "editButton": "Alle bearbeiten",
+        "resetButton": "Auf Default zurücksetzen",
+        "saveButton": "Alle speichern"
       },
       "connections": {
         "aasRepository": {
@@ -347,6 +347,9 @@
           "create": "Regel erstellen",
           "edit": "Bearbeiten",
           "save": "Speichern"
+        },
+        "errors": {
+          "uniqueIdShort": "Die Kombination aus Rollenname, Aktion und Typ existiert bereits in einer anderen Regel.\nBitte bearbeiten Sie die bestehende Regel."
         },
         "createTitle": "Regel erstellen",
         "editTitle": "Regel bearbeiten",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -282,10 +282,10 @@
     },
     "settings": {
       "actions": {
-          "cancel": "Cancel",
-          "editButton": "Edit all",
-          "resetButton": "Reset to default",
-          "saveButton": "Save all"
+        "cancel": "Cancel",
+        "editButton": "Edit all",
+        "resetButton": "Reset to default",
+        "saveButton": "Save all"
       },
       "connections": {
         "aasRepository": {
@@ -347,6 +347,9 @@
           "create": "Create Rule",
           "edit": "Edit",
           "save": "Save"
+        },
+        "errors": {
+          "uniqueIdShort": "The combination of role name, action and type already exists in another rule.\nPlease edit the existing rule."
         },
         "createTitle": "Create Rule",
         "editTitle": "Edit Rule",


### PR DESCRIPTION
# Description

Adds a notification for the error when creating a non unique idShort in create and update.

Fixes MNES-1647

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
