### PR TITLE
[WIP] feat(xeco): make cypress image better

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -121,8 +121,8 @@ jobs:
       #- name: Build test image
       #  run: docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests build cypress-test
 
-      - name: Pull images
-        run: docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests pull
+      #- name: Pull images
+      #  run: docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests pull
 
       # Remove old image to avoid conflicts, before sometimes the old image wasn't loaded
       # If this step fails please check docker-compose/compose.test.yml if tag is still correct
@@ -139,6 +139,7 @@ jobs:
         # the number of containers to run more tests in parallel.
         timeout-minutes: 18
         run: |
+          docker image ls -a
           docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests up -d &&
           docker compose -f compose.yml -f docker-compose/compose.test.yml attach cypress-test
         env:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -60,11 +60,34 @@ jobs:
         with:
           path: mnestix-browser.tar
           key: docker-image-${{github.ref}}-${{ github.run_id }}
+          
+  build-cypress-image:
+    name: Build cypress image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and export
+        uses: docker/build-push-action@v6
+        with:
+          file: cypress.dockerfile
+          tags: cypress-test:runner
+          outputs: type=docker,dest=${{ runner.temp }}/cypress-test.tar
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-test
+          path: ${{ runner.temp }}/cypress-test.tar
 
   e2e-tests:
     name: e2e test matrix
     runs-on: ubuntu-latest
-    needs: ['build-browser-image']
+    needs: ['build-browser-image', 'build-cypress-image']
     permissions:
       contents: read
     strategy:
@@ -77,6 +100,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Download Test-Image
+        uses: actions/download-artifact@v4
+        with:
+          name: cypress-test
+          path: ${{ runner.temp }}
+
+      - name: Load cypress image
+        run: |
+          docker load --input ${{ runner.temp }}/cypress-test.tar
+          docker image ls -a
+
       - name: Restore image
         uses: actions/cache/restore@v4
         with:
@@ -84,20 +118,20 @@ jobs:
           key: docker-image-${{github.ref}}-${{ github.run_id }}
 
       # image too big to be reused
-      - name: Build test image
-        run: docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests build cypress-test
+      #- name: Build test image
+      #  run: docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests build cypress-test
 
       - name: Pull images
         run: docker compose -f compose.yml -f docker-compose/compose.test.yml --profile tests pull
 
       # Remove old image to avoid conflicts, before sometimes the old image wasn't loaded
       # If this step fails please check docker-compose/compose.test.yml if tag is still correct
-      - name: Remove Docker image mnestix/mnestix-browser:latest, to avoid conflicts
-        run: docker rmi mnestix/mnestix-browser:latest
+      #- name: Remove Docker image mnestix/mnestix-browser:latest, to avoid conflicts
+      #  run: docker rmi mnestix/mnestix-browser:latest
 
       # overwrite the pulled image with the new image
-      - name: Load mnestix-browser image
-        run: docker load -i mnestix-browser.tar
+      #- name: Load mnestix-browser image
+      #  run: docker load -i mnestix-browser.tar
 
       - name: Run e2e tests
         # 18-minute timeout to speed up failing tests that are retried too long.

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,7 +5,6 @@ on:
     branches: ['main', 'dev', 'staging']
     tags: ['v*.*.*']
   pull_request:
-    branches: ['dev']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/cypress.dockerfile
+++ b/cypress.dockerfile
@@ -4,13 +4,8 @@ RUN mkdir /cypress_Tests
 WORKDIR /cypress_Tests
 COPY ./package.json ./package.json
 COPY ./yarn.lock ./yarn.lock
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  libgtk2.0-0 \
-  libx11-xcb1 \
-  libxkbcommon-x11-0 \
-  libasound2 \
-  fonts-chrome \
-  chromium
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends libgtk2.0-0 libx11-xcb1 libxkbcommon-x11-0 libasound2 fonts-freefont-ttf chromium
 RUN apt-get install -y python3 python3-setuptools make g++
  
 RUN yarn add cypress --dev

--- a/cypress.dockerfile
+++ b/cypress.dockerfile
@@ -1,16 +1,20 @@
-FROM cypress/included:14.1.0
-
+FROM node:18-slim
 ENV NO_COLOR=1
-
 RUN mkdir /cypress_Tests
-
 WORKDIR /cypress_Tests
-
 COPY ./package.json ./package.json
 COPY ./yarn.lock ./yarn.lock
-
-RUN apt-get update && apt-get install -y python3 python3-setuptools make g++
-RUN yarn install
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libgtk2.0-0 \
+  libx11-xcb1 \
+  libxkbcommon-x11-0 \
+  libasound2 \
+  fonts-chrome \
+  chromium
+RUN apt-get install -y python3 python3-setuptools make g++
  
+RUN yarn add cypress --dev
+ 
+RUN yarn install
 # Enable setting additional argument on bin directly
 ENTRYPOINT ["./node_modules/.bin/cypress"]


### PR DESCRIPTION
# Description

This should cache the cypress image and also make it much smaller.
It may also improve the speed of the pipeline, because the cypress image can be build in parallel to the browser image.

Fixes # (XECO)

## Type of change

-   [x] Minor change (non-breaking change, e.g. documentation adaption)

# Checklist:

-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
