### PR TITLE
fix(rbac): add validation for role name length

### DIFF
--- a/src/app/[locale]/settings/_components/role-settings/RuleForm.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleForm.tsx
@@ -68,6 +68,14 @@ export const RuleForm = ({ onCancel, onSubmit, rule, title, availableRoles }: Ru
                     <Controller
                         rules={{
                             required: t('roleRequired'),
+                            maxLength: {
+                                value: 1000 /* A theoretical jetty server can handle 2048 url length. */,
+                                message: t('roleNameMaxLength', { maxLength: 1000 }),
+                            },
+                            pattern: {
+                                value: /^.*\S$/,
+                                message: t('roleNameNoTrailSpace'),
+                            },
                         }}
                         name="role"
                         control={control}
@@ -111,10 +119,7 @@ export const RuleForm = ({ onCancel, onSubmit, rule, title, availableRoles }: Ru
                                     {...field}
                                 >
                                     {rbacRuleActions.map((action) => (
-                                        <MenuItem
-                                            value={action}
-                                            data-testid={`rule-settings-action-${action}`}
-                                        >
+                                        <MenuItem value={action} data-testid={`rule-settings-action-${action}`}>
                                             {action}
                                         </MenuItem>
                                     ))}

--- a/src/lib/services/rbac-service/RbacActions.ts
+++ b/src/lib/services/rbac-service/RbacActions.ts
@@ -12,7 +12,7 @@ import { createRequestLogger, logInfo, logWarn } from 'lib/util/Logger';
 import { headers } from 'next/headers';
 import baseLogger from 'lib/util/Logger';
 
-async function validateRequest(logger: typeof baseLogger) {
+async function getRequestErrorOrUndefined(logger: typeof baseLogger) {
     const session = await getServerSession(authOptions);
     if (!session) {
         return wrapErrorCode(ApiResultStatus.UNAUTHORIZED, 'Unauthorized');
@@ -36,9 +36,9 @@ async function validateRequest(logger: typeof baseLogger) {
  */
 export async function createRbacRule(newRule: Omit<BaSyxRbacRule, 'idShort'>) {
     const logger = createRequestLogger(await headers());
-    const invalid = await validateRequest(logger);
-    if (invalid) {
-        return invalid;
+    const errorWrapper = await getRequestErrorOrUndefined(logger);
+    if (errorWrapper) {
+        return errorWrapper;
     }
     logInfo(logger, 'createRbacRule', 'Creating new RBAC rule', { New_rule: newRule.role });
     const client = RbacRulesService.createService(logger);
@@ -51,9 +51,9 @@ export async function createRbacRule(newRule: Omit<BaSyxRbacRule, 'idShort'>) {
  */
 export async function getRbacRules() {
     const logger = createRequestLogger(await headers());
-    const invalid = await validateRequest(logger);
-    if (invalid) {
-        return invalid;
+    const errorWrapper = await getRequestErrorOrUndefined(logger);
+    if (errorWrapper) {
+        return errorWrapper;
     }
     logInfo(logger, 'getRbacRules', 'Querying all RBAC rules');
     const client = RbacRulesService.createService(logger);
@@ -66,9 +66,9 @@ export async function getRbacRules() {
  */
 export async function deleteRbacRule(idShort: string) {
     const logger = createRequestLogger(await headers());
-    const invalid = await validateRequest(logger);
-    if (invalid) {
-        return invalid;
+    const errorWrapper = await getRequestErrorOrUndefined(logger);
+    if (errorWrapper) {
+        return errorWrapper;
     }
     logInfo(logger, 'deleteRbacRule', 'Deleting RBAC rule', { Rule_idShort: idShort });
     const client = RbacRulesService.createService(logger);
@@ -81,9 +81,9 @@ export async function deleteRbacRule(idShort: string) {
  */
 export async function deleteAndCreateRbacRule(idShort: string, rule: BaSyxRbacRule) {
     const logger = createRequestLogger(await headers());
-    const invalid = await validateRequest(logger);
-    if (invalid) {
-        return invalid;
+    const errorWrapper = await getRequestErrorOrUndefined(logger);
+    if (errorWrapper) {
+        return errorWrapper;
     }
     logInfo(logger, 'deleteAndCreateRbacRule', 'Deleting and creating RBAC rule', {
         Rule_idShort: idShort,

--- a/src/lib/services/rbac-service/RbacRulesService.spec.ts
+++ b/src/lib/services/rbac-service/RbacRulesService.spec.ts
@@ -6,6 +6,7 @@ import ServiceReachable from 'test-utils/TestUtils';
 import { SubmodelRepositoryApi } from 'lib/api/basyx-v3/api';
 import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 import { ApiResultStatus } from 'lib/util/apiResponseWrapper/apiResultStatus';
+import { range } from 'lodash';
 
 const correctRules = testData.correct as JsonValue;
 const warningRules = testData.warning as JsonValue;
@@ -45,15 +46,14 @@ describe('RbacRulesService', () => {
     });
 
     describe('create', () => {
+        const subApiMock = {
+            postSubmodelElement: jest.fn().mockResolvedValue({
+                isSuccess: true,
+                result: testData.correct.submodelElements[0],
+            } satisfies ApiResponseWrapper<unknown>),
+            getSubmodelById: () => Promise.resolve({ isSuccess: true, result: testData.correct }),
+        } as unknown as SubmodelRepositoryApi;
         it('should convert rule to the correct idShort', async () => {
-            const subApiMock = {
-                postSubmodelElement: jest.fn().mockResolvedValue({
-                    isSuccess: true,
-                    result: testData.correct.submodelElements[0],
-                } satisfies ApiResponseWrapper<unknown>),
-                getSubmodelById: () => Promise.resolve({ isSuccess: true, result: testData.correct }),
-            } as unknown as SubmodelRepositoryApi;
-
             const service = RbacRulesService.createNull(subApiMock);
 
             await service.createRule({
@@ -70,6 +70,19 @@ describe('RbacRulesService', () => {
                 }),
             );
         });
+        it('should return bad request if rule is invalid', async () => {
+            const service = RbacRulesService.createNull(subApiMock);
+            const res = await service.createRule({
+                action: 'DELETE',
+                role: range(1001).join(''),
+                targetInformation: { '@type': 'aas', aasIds: ['*'] },
+            });
+            if (res.isSuccess) {
+                fail('Expected error, but got success');
+            }
+            expect(res.errorCode).toBe(ApiResultStatus.BAD_REQUEST);
+        });
+
         it('should show error if idShort already exists', async () => {
             const service = RbacRulesService.createNull(
                 SubmodelRepositoryApi.createNull('', [submodelFromJsonable(correctRules).mustValue()]),

--- a/src/lib/services/rbac-service/RbacRulesService.ts
+++ b/src/lib/services/rbac-service/RbacRulesService.ts
@@ -34,6 +34,11 @@ export class RbacRulesService {
     }
 
     async createRule(newRule: Omit<BaSyxRbacRule, 'idShort'>): Promise<ApiResponseWrapper<BaSyxRbacRule>> {
+        const error = this.hasRuleError(newRule);
+        if (error) {
+            return wrapErrorCode(ApiResultStatus.BAD_REQUEST, error);
+        }
+
         const newIdShort = ruleToIdShort(newRule);
         if (!(await this.isIdShortUnique(newIdShort))) {
             return wrapErrorCode(
@@ -111,8 +116,12 @@ export class RbacRulesService {
         idShort: string,
         newRule: Omit<BaSyxRbacRule, 'idShort'>,
     ): Promise<ApiResponseWrapper<BaSyxRbacRule>> {
-        const newIdShort = ruleToIdShort(newRule);
+        const error = this.hasRuleError(newRule);
+        if (error) {
+            return wrapErrorCode(ApiResultStatus.BAD_REQUEST, error);
+        }
 
+        const newIdShort = ruleToIdShort(newRule);
         if (idShort !== newIdShort && !(await this.isIdShortUnique(newIdShort))) {
             return wrapErrorCode(
                 ApiResultStatus.CONFLICT,
@@ -181,5 +190,12 @@ export class RbacRulesService {
         }
 
         return !rules.result.roles.find((e) => e.idShort === idShort);
+    }
+
+    private hasRuleError(rule: Omit<BaSyxRbacRule, 'idShort'>) {
+        if (rule.role.length > 1000) {
+            return 'Role name is too long';
+        }
+        return undefined;
     }
 }

--- a/src/lib/services/rbac-service/RbacRulesService.ts
+++ b/src/lib/services/rbac-service/RbacRulesService.ts
@@ -34,7 +34,7 @@ export class RbacRulesService {
     }
 
     async createRule(newRule: Omit<BaSyxRbacRule, 'idShort'>): Promise<ApiResponseWrapper<BaSyxRbacRule>> {
-        const error = this.hasRuleError(newRule);
+        const error = getRuleErrorOrUndefined(newRule);
         if (error) {
             return wrapErrorCode(ApiResultStatus.BAD_REQUEST, error);
         }
@@ -116,9 +116,9 @@ export class RbacRulesService {
         idShort: string,
         newRule: Omit<BaSyxRbacRule, 'idShort'>,
     ): Promise<ApiResponseWrapper<BaSyxRbacRule>> {
-        const error = this.hasRuleError(newRule);
-        if (error) {
-            return wrapErrorCode(ApiResultStatus.BAD_REQUEST, error);
+        const errorMsg = getRuleErrorOrUndefined(newRule);
+        if (errorMsg) {
+            return wrapErrorCode(ApiResultStatus.BAD_REQUEST, errorMsg);
         }
 
         const newIdShort = ruleToIdShort(newRule);
@@ -191,11 +191,11 @@ export class RbacRulesService {
 
         return !rules.result.roles.find((e) => e.idShort === idShort);
     }
+}
 
-    private hasRuleError(rule: Omit<BaSyxRbacRule, 'idShort'>) {
-        if (rule.role.length > 1000) {
-            return 'Role name is too long';
-        }
-        return undefined;
+function getRuleErrorOrUndefined(rule: Omit<BaSyxRbacRule, 'idShort'>) {
+    if (rule.role.length > 1000) {
+        return 'Role name is too long';
     }
+    return undefined;
 }

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -406,6 +406,8 @@
         },
         "keycloakHint": "Es haben sich Rollen geändert. Um diese Benutzern zuzuweisen, konfigurieren Sie diese unter '{url}'.",
         "roleRequired": "Rolle wird benötigt",
+        "roleNameMaxLength": "Rollenname darf maximal {maxLength} Zeichen lang sein",
+        "roleNameNoTrailSpace": "Rollenname darf keine Leerzeichen am Ende haben.",
         "subtitle": "Verwalten von Rollen und Berechtigungen.",
         "tableHeader": {
           "aasIds": "AAS IDs",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -406,6 +406,8 @@
         },
         "keycloakHint": "Some Roles have changed. To assign users, configurate them at '{url}'.",
         "roleRequired": "Role is required",
+        "roleNameMaxLength": "Role name cannot be longer than {maxLength} characters.",
+        "roleNameNoTrailSpace": "Role name cannot end with a space.",
         "subtitle": "Manage roles and permissions.",
         "tableHeader": {
           "aasIds": "AAS IDs",


### PR DESCRIPTION
# Description

add validation for role name length. This is not a BaSyx bug we have to ensure the name is not too long.

I added a check for spaces at the end too but that's just for easier use.

Fixes MNE-86

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix or my feature works
-   [x] New and existing tests pass locally with my changes
-   [x] My changes contain no console logs
