### PR TITLE
feat(rbac): show keycloak link in hint dialog

### DIFF
--- a/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.spec.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.spec.tsx
@@ -140,11 +140,13 @@ describe('CreateRuleDialog', () => {
         await waitFor(() => {
             expect(onClose).not.toHaveBeenCalled();
             expect(reloadRules).toHaveBeenCalled();
-            expect(screen.getByText('pages.settings.rules.createRule.hint.text')).toBeInTheDocument();
+            expect(screen.getByText('pages.settings.rules.keycloakHint.create')).toBeInTheDocument();
+            expect(screen.getByTestId('role-hint-acknowledge')).toBeInTheDocument();
+            expect(screen.getByTestId('role-hint-keycloak')).toBeInTheDocument();
         });
 
         await act(async () => {
-            fireEvent.click(screen.getByTestId('role-create-hint-acknowledge'));
+            fireEvent.click(screen.getByTestId('role-hint-acknowledge'));
         });
 
         await waitFor(() => {

--- a/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.tsx
@@ -8,7 +8,7 @@ import { useShowError } from 'lib/hooks/UseShowError';
 import { useNotificationSpawner } from 'lib/hooks/UseNotificationSpawner';
 import { RuleForm, RuleFormModel } from 'app/[locale]/settings/_components/role-settings/RuleForm';
 import { useState } from 'react';
-import { CreateHint } from 'app/[locale]/settings/_components/role-settings/HintDialogContent';
+import { KeycloakHint } from 'app/[locale]/settings/_components/role-settings/HintDialogContent';
 
 type RoleDialogProps = {
     readonly onClose: () => void;
@@ -79,7 +79,7 @@ export const CreateRuleDialog = ({ onClose, reloadRules, open, availableRoles }:
             <Box sx={{ mx: '2rem', mt: '1.5rem', mb: '1rem' }} data-testid="role-create-dialog">
                 <DialogCloseButton handleClose={onClose} dataTestId="rule-create-close-button" />
                 {showHint ? (
-                    <CreateHint onClose={onClose} />
+                    <KeycloakHint hint="create" onClose={onClose} />
                 ) : (
                     <RuleForm
                         title={t('createRule.title')}

--- a/src/app/[locale]/settings/_components/role-settings/HintDialogContent.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/HintDialogContent.tsx
@@ -25,6 +25,7 @@ export function KeycloakHint({ onClose, hint }: { onClose: () => void; hint: 'cr
                     variant="contained"
                     target="_blank"
                     color="primary"
+                    data-testid="role-hint-keycloak"
                 >
                     Keycloak
                 </Button>
@@ -34,7 +35,7 @@ export function KeycloakHint({ onClose, hint }: { onClose: () => void; hint: 'cr
                     startIcon={<CheckIcon />}
                     variant="contained"
                     onClick={onClose}
-                    data-testid="role-create-hint-acknowledge"
+                    data-testid="role-hint-acknowledge"
                 >
                     {t('acknowledge')}
                 </Button>

--- a/src/app/[locale]/settings/_components/role-settings/HintDialogContent.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/HintDialogContent.tsx
@@ -2,7 +2,7 @@ import { Button, DialogActions, DialogContent, Typography } from '@mui/material'
 import CheckIcon from '@mui/icons-material/Check';
 import { useTranslations } from 'next-intl';
 import { useEnv } from 'app/EnvProvider';
-import { ArrowRightAlt } from '@mui/icons-material';
+import { OpenInNew } from '@mui/icons-material';
 
 export function KeycloakHint({ onClose, hint }: { onClose: () => void; hint: 'create' | 'delete' }) {
     const t = useTranslations('pages.settings.rules.keycloakHint');
@@ -20,7 +20,7 @@ export function KeycloakHint({ onClose, hint }: { onClose: () => void; hint: 'cr
                     {t(hint)}
                 </Typography>
                 <Button
-                    startIcon={<ArrowRightAlt />}
+                    startIcon={<OpenInNew />}
                     href={keycloakUrl.toString()}
                     variant="contained"
                     target="_blank"

--- a/src/app/[locale]/settings/_components/role-settings/HintDialogContent.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/HintDialogContent.tsx
@@ -1,9 +1,14 @@
 import { Button, DialogActions, DialogContent, Typography } from '@mui/material';
 import CheckIcon from '@mui/icons-material/Check';
 import { useTranslations } from 'next-intl';
+import { useEnv } from 'app/EnvProvider';
+import { ArrowRightAlt } from '@mui/icons-material';
 
-export function CreateHint({ onClose }: { onClose: () => void }) {
-    const t = useTranslations('pages.settings.rules.createRule.hint');
+export function KeycloakHint({ onClose, hint }: { onClose: () => void; hint: 'create' | 'delete' }) {
+    const t = useTranslations('pages.settings.rules.keycloakHint');
+    const envs = useEnv();
+
+    const keycloakUrl = new URL(`/admin/master/console/#/${envs.KEYCLOAK_REALM}/roles`, envs.KEYCLOAK_ISSUER);
 
     return (
         <>
@@ -11,9 +16,18 @@ export function CreateHint({ onClose }: { onClose: () => void }) {
                 <Typography variant="h2" color="primary" sx={{ mb: '1rem' }}>
                     {t('title')}
                 </Typography>
-                <Typography variant="body1" color="text.secondary">
-                    {t('text')}
+                <Typography variant="body1" color="text.secondary" sx={{ mb: '0.5rem' }}>
+                    {t(hint)}
                 </Typography>
+                <Button
+                    startIcon={<ArrowRightAlt />}
+                    href={keycloakUrl.toString()}
+                    variant="contained"
+                    target="_blank"
+                    color="primary"
+                >
+                    Keycloak
+                </Button>
             </DialogContent>
             <DialogActions>
                 <Button
@@ -21,33 +35,6 @@ export function CreateHint({ onClose }: { onClose: () => void }) {
                     variant="contained"
                     onClick={onClose}
                     data-testid="role-create-hint-acknowledge"
-                >
-                    {t('acknowledge')}
-                </Button>
-            </DialogActions>
-        </>
-    );
-}
-
-export function DeleteHint({ onClose }: { onClose: () => void }) {
-    const t = useTranslations('pages.settings.rules.deleteRule.hint');
-
-    return (
-        <>
-            <DialogContent>
-                <Typography variant="h2" color="primary" sx={{ mb: '1rem' }}>
-                    {t('title')}
-                </Typography>
-                <Typography variant="body1" color="text.secondary">
-                    {t('text')}
-                </Typography>
-            </DialogContent>
-            <DialogActions>
-                <Button
-                    startIcon={<CheckIcon />}
-                    variant="contained"
-                    onClick={onClose}
-                    data-testid="role-delete-hint-acknowledge"
                 >
                     {t('acknowledge')}
                 </Button>

--- a/src/app/[locale]/settings/_components/role-settings/RuleDialog.spec.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleDialog.spec.tsx
@@ -152,7 +152,17 @@ describe('RoleDialog', () => {
         await waitFor(() => {
             expect(onClose).not.toHaveBeenCalled();
             expect(reloadRules).toHaveBeenCalled();
-            expect(screen.getByTestId('role-delete-hint-acknowledge')).toBeInTheDocument();
+            expect(screen.getByText('pages.settings.rules.keycloakHint.delete')).toBeInTheDocument();
+            expect(screen.getByTestId('role-hint-acknowledge')).toBeInTheDocument();
+            expect(screen.getByTestId('role-hint-keycloak')).toBeInTheDocument();
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('role-hint-acknowledge'));
+        });
+
+        await waitFor(() => {
+            expect(onClose).toHaveBeenCalled();
         });
     });
 
@@ -171,7 +181,17 @@ describe('RoleDialog', () => {
         await waitFor(() => {
             expect(onClose).not.toHaveBeenCalled();
             expect(reloadRules).toHaveBeenCalled();
-            expect(screen.getByTestId('role-create-hint-acknowledge')).toBeInTheDocument();
+            expect(screen.getByText('pages.settings.rules.keycloakHint.create')).toBeInTheDocument();
+            expect(screen.getByTestId('role-hint-acknowledge')).toBeInTheDocument();
+            expect(screen.getByTestId('role-hint-keycloak')).toBeInTheDocument();
+        });
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('role-hint-acknowledge'));
+        });
+
+        await waitFor(() => {
+            expect(onClose).toHaveBeenCalled();
         });
     });
 
@@ -251,6 +271,7 @@ describe('RoleDialog', () => {
             });
             expect(onClose).toHaveBeenCalled();
             expect(reloadRules).toHaveBeenCalled();
+            expect(screen.queryByText('pages.settings.rules.keycloakHint.delete')).not.toBeInTheDocument();
         });
     });
 
@@ -269,10 +290,13 @@ describe('RoleDialog', () => {
             expect(deleteRbacRule).toHaveBeenCalledWith(lastRuleForRole.idShort);
             expect(onClose).not.toHaveBeenCalled();
             expect(reloadRules).toHaveBeenCalled();
-            expect(screen.getByTestId('role-delete-hint-acknowledge')).toBeInTheDocument();
+            expect(screen.getByText('pages.settings.rules.keycloakHint.delete')).toBeInTheDocument();
+            expect(screen.getByTestId('role-hint-acknowledge')).toBeInTheDocument();
+            expect(screen.getByTestId('role-hint-keycloak')).toBeInTheDocument();
         });
-
-        fireEvent.click(screen.getByTestId('role-delete-hint-acknowledge'));
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('role-delete-hint-acknowledge'));
+        });
 
         await waitFor(() => {
             expect(onClose).toHaveBeenCalled();
@@ -298,6 +322,8 @@ describe('RoleDialog', () => {
             expect(screen.getByTestId('role-settings-dialog')).toBeInTheDocument();
             expect(onClose).not.toHaveBeenCalled();
             expect(reloadRules).not.toHaveBeenCalled();
+            expect(screen.queryByText('pages.settings.rules.keycloakHint.create')).not.toBeInTheDocument();
+            expect(screen.queryByText('pages.settings.rules.keycloakHint.delete')).not.toBeInTheDocument();
         });
     });
 });

--- a/src/app/[locale]/settings/_components/role-settings/RuleDialog.spec.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleDialog.spec.tsx
@@ -1,18 +1,25 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { DialogRbacRule, RuleDialog } from 'app/[locale]/settings/_components/role-settings/RuleDialog';
 import { createRbacRule, deleteAndCreateRbacRule, deleteRbacRule } from 'lib/services/rbac-service/RbacActions';
 import { expect } from '@jest/globals';
 import { useNotificationSpawner } from 'lib/hooks/UseNotificationSpawner';
 import { ApiResultStatus } from 'lib/util/apiResponseWrapper/apiResultStatus';
 import { mockRbacRoles } from './test-data/mockRbacRoles';
-import { act } from 'react';
 import { ApiResponseWrapperError, wrapErrorCode, wrapSuccess } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
+import { EnvProvider } from 'app/EnvProvider';
 
 jest.mock('./../../../../../lib/services/rbac-service/RbacActions');
 jest.mock('next-intl', () => ({
     useTranslations: (scope?: string) => (key: string) => (scope ? `${scope}.${key}` : key),
 }));
 jest.mock('./../../../../../lib/hooks/UseNotificationSpawner');
+jest.mock('./../../../../../lib/services/envAction', () => ({
+    getEnv: jest.fn().mockResolvedValue({
+        KEYCLOAK_ISSUER: 'http://test-keycloak.dev:8080',
+        KEYCLOAK_LOCAL_URL: 'http://localhost:8080',
+        KEYCLOAK_REALM: 'test-realm',
+    }),
+}));
 
 const notLastRuleForRole: DialogRbacRule = {
     ...mockRbacRoles.roles[0],
@@ -43,6 +50,9 @@ async function renderRuleDialog(rule: DialogRbacRule) {
                 reloadRules={reloadRules}
                 availableRoles={availableRoles}
             />,
+            {
+                wrapper: ({ children }) => <EnvProvider>{children}</EnvProvider>,
+            },
         );
     });
 
@@ -295,7 +305,7 @@ describe('RoleDialog', () => {
             expect(screen.getByTestId('role-hint-keycloak')).toBeInTheDocument();
         });
         await act(async () => {
-            fireEvent.click(screen.getByTestId('role-delete-hint-acknowledge'));
+            fireEvent.click(screen.getByTestId('role-hint-acknowledge'));
         });
 
         await waitFor(() => {

--- a/src/app/[locale]/settings/_components/role-settings/RuleDialog.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleDialog.tsx
@@ -11,7 +11,7 @@ import { useShowError } from 'lib/hooks/UseShowError';
 import { useNotificationSpawner } from 'lib/hooks/UseNotificationSpawner';
 import { RuleForm, RuleFormModel } from 'app/[locale]/settings/_components/role-settings/RuleForm';
 import { BaSyxRbacRule } from 'lib/services/rbac-service/types/RbacServiceData';
-import { CreateHint, DeleteHint } from 'app/[locale]/settings/_components/role-settings/HintDialogContent';
+import { KeycloakHint } from 'app/[locale]/settings/_components/role-settings/HintDialogContent';
 import { RuleDeleteDialog } from 'app/[locale]/settings/_components/role-settings/RuleDeleteDialog';
 import { CopyButton } from 'components/basics/CopyButton';
 
@@ -170,9 +170,9 @@ export const RuleDialog = ({ onClose, reloadRules, open, rule, availableRoles }:
                     <RuleDeleteDialog rule={rule} onCancelDialog={() => setDialogMode('view')} onDelete={onDelete} />
                 );
             case 'create-hint':
-                return <CreateHint onClose={onClose} />;
+                return <KeycloakHint hint="create" onClose={onClose} />;
             case 'delete-hint':
-                return <DeleteHint onClose={onClose} />;
+                return <KeycloakHint hint="delete" onClose={onClose} />;
             default:
                 return <ViewContent />;
         }

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -379,20 +379,10 @@
           "save": "Speichern"
         },
         "createRule": {
-          "hint": {
-            "acknowledge": "In Ordnung",
-            "text": "Eine neue Rolle wurde erstellt. Vergessen Sie nicht die Rolle in Keycloak zu konfigurieren.",
-            "title": "Keycloak aktualisieren"
-          },
           "saveSuccess": "Neue Regel erfolgreich gespeichert.",
           "title": "Regel erstellen"
         },
         "deleteRule": {
-          "hint": {
-            "acknowledge": "Verstanden",
-            "text": "Vergessen Sie nicht die Regel in keycloak zu entfernen!",
-            "title": "Regel löschen"
-          },
           "question": "Regel unwiderruflich löschen?",
           "ruleInfo": "Nutzer mit der Rolle ''{role}'' haben danach keine Berrechtigungen mehr die folgenden Daten {action, select, READ {zu LESEN} EDIT {zu EDITIEREN} CREATE {zu ERSTELLEN} UPDATE {zu VERÄNDERN} EXECUTE {AUSZUFÜHREN}  other {#}}!",
           "success": "Regel erfolgreich gelöscht."
@@ -404,7 +394,12 @@
         "errors": {
           "uniqueIdShort": "Die Kombination aus Rollenname, Aktion und Typ existiert bereits in einer anderen Regel.\nBitte bearbeiten Sie die bestehende Regel."
         },
-        "keycloakHint": "Es haben sich Rollen geändert. Um diese Benutzern zuzuweisen, konfigurieren Sie diese unter '{url}'.",
+        "keycloakHint": {
+          "acknowledge": "In Ordnung",
+          "create": "Diese Rolle wurde bisher nicht verwendet. Vergessen Sie nicht diese auch in Keycloak zu konfigurieren!",
+          "delete": "Vergessen Sie nicht die Rolle in Keycloak zu entfernen!",
+          "title": "Keycloak aktualisieren"
+        },
         "roleRequired": "Rolle wird benötigt",
         "subtitle": "Verwalten von Rollen und Berechtigungen.",
         "tableHeader": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -379,20 +379,10 @@
           "save": "Save"
         },
         "createRule": {
-          "hint": {
-            "acknowledge": "Acknowledge",
-            "text": "A new Role has been created. Configure it in keycloak.",
-            "title": "Update Keycloak"
-          },
           "saveSuccess": "New rule saved successfully.",
           "title": "Create Rule"
         },
         "deleteRule": {
-          "hint": {
-            "acknowledge": "Acknowledged",
-            "text": "Do not forget to delete this rule in keycloak as well!",
-            "title": "Delete rule"
-          },
           "question": "Permanently delete this rule?",
           "ruleInfo": "Users with the assigned role ''{role}'' will not have permissions to {action} the following data!",
           "success": "Rule deleted successfully."
@@ -404,7 +394,12 @@
         "errors": {
           "uniqueIdShort": "The combination of role name, action and type already exists in another rule.\nPlease edit the existing rule."
         },
-        "keycloakHint": "Some Roles have changed. To assign users, configurate them at '{url}'.",
+        "keycloakHint": {
+          "acknowledge": "Acknowledge",
+          "create": "This role has not been used yet. Don't forget to configure it in Keycloak!",
+          "delete": "Do not forget to delete this role in Keycloak as well!",
+          "title": "Update Keycloak"
+        },
         "roleRequired": "Role is required",
         "subtitle": "Manage roles and permissions.",
         "tableHeader": {


### PR DESCRIPTION
# Description

A button. When the user clicks it, you are redirected to the used keycloak instance admin page.

![image](https://github.com/user-attachments/assets/b9520e95-d114-4ff5-acfa-ffbf56f531e2)
![image](https://github.com/user-attachments/assets/3d089f08-c6a5-47b3-bad4-06a240c379aa)

Fixes # (MNE-114)

## Type of change

-   [x] New feature (non-breaking change which adds functionality)

# Checklist:

-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix or my feature works
-   [x] New and existing tests pass locally with my changes
-   [x] My changes contain no console logs
