### PR TITLE
fix(transfer): apiKey can be used for the targetRepository

### DIFF
--- a/src/lib/api/infrastructure.ts
+++ b/src/lib/api/infrastructure.ts
@@ -13,8 +13,11 @@ const initializeRequestOptions = async (bearerToken: string, init?: RequestInit)
         };
     } else if (!envs.AUTHENTICATION_FEATURE_FLAG) {
         init.headers = {
-            ...init.headers,
             ApiKey: envs.MNESTIX_BACKEND_API_KEY || '',
+            // Overriding the ApiKey from the Mnestix configuration with the one
+            // set in the function call as the transfer feature allows users
+            // to set a separate ApiKey for the target repository.
+            ...init.headers,
         };
     }
 


### PR DESCRIPTION
# Description

apiKey was overwritten by envs. Now the function call ApiKey has preference.

Fixes MNE-120

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [x] New and existing tests pass locally with my changes
-   [x] My changes contain no console logs
