### PR TITLE
fix(Nameplate): Add support for new Nameplate Semantic ID

### DIFF
--- a/src/app/[locale]/product/[base64AasId]/page.tsx
+++ b/src/app/[locale]/product/[base64AasId]/page.tsx
@@ -48,6 +48,7 @@ export default function Page() {
                         checkIfSubmodelHasIdShortOrSemanticId(submodel, SubmodelSemanticIdEnum.NameplateV1, 'Nameplate') ||
                         checkIfSubmodelHasIdShortOrSemanticId(submodel, SubmodelSemanticIdEnum.NameplateV2, 'Nameplate') ||
                         checkIfSubmodelHasIdShortOrSemanticId(submodel, SubmodelSemanticIdEnum.NameplateV3, 'Nameplate') ||
+                        checkIfSubmodelHasIdShortOrSemanticId(submodel, SubmodelSemanticIdEnum.NameplateV4, 'Nameplate') ||
                         checkIfSubmodelHasIdShortOrSemanticId(submodel, undefined, 'VEC_SML'))
             );
             setFilteredSubmodels(filtered);

--- a/src/app/[locale]/viewer/_components/submodel/sorting/SortNameplateElements.ts
+++ b/src/app/[locale]/viewer/_components/submodel/sorting/SortNameplateElements.ts
@@ -25,6 +25,7 @@ export function SortNameplateElements(submodel: Submodel | SubmodelElementCollec
         SubmodelSemanticIdEnum.NameplateV1,
         SubmodelSemanticIdEnum.NameplateV2,
         SubmodelSemanticIdEnum.NameplateV3,
+        SubmodelSemanticIdEnum.NameplateV4,
     ];
     if (nameplateKeys.includes(<SubmodelSemanticIdEnum>key)) {
         SortSubmodelElements(submodels, NameplateSorting);

--- a/src/lib/enums/SubmodelSemanticId.enum.ts
+++ b/src/lib/enums/SubmodelSemanticId.enum.ts
@@ -10,6 +10,7 @@ export enum SubmodelSemanticIdEnum {
     NameplateV1 = 'https://admin-shell.io/zvei/nameplate/1/0/Nameplate',
     NameplateV2 = 'https://admin-shell.io/zvei/nameplate/2/0/Nameplate',
     NameplateV3 = 'https://admin-shell.io/zvei/nameplate/3/0/Nameplate',
+    NameplateV4 = 'https://admin-shell.io/idta/nameplate/3/0/Nameplate',
     BillOfApplications = 'https://xitaso.com/BillOfApplications',
     TechnicalDataV11 = 'https://admin-shell.io/ZVEI/TechnicalData/Submodel/1/1',
     TechnicalDataV12 = 'https://admin-shell.io/ZVEI/TechnicalData/Submodel/1/2',

--- a/src/lib/services/list-service/ListService.ts
+++ b/src/lib/services/list-service/ListService.ts
@@ -118,6 +118,7 @@ export class ListService {
                     SubmodelSemanticIdEnum.NameplateV1,
                     SubmodelSemanticIdEnum.NameplateV2,
                     SubmodelSemanticIdEnum.NameplateV3,
+                    SubmodelSemanticIdEnum.NameplateV4,
                 ];
                 if (nameplateKeys.includes(<SubmodelSemanticIdEnum>semanticId)) {
                     const manufacturerName = await this.submodelRepositoryClient.getSubmodelElement(


### PR DESCRIPTION
Introduce support for new Nameplate Semantic ID by updating the relevant enums and functions to include the new semantic ID.

As you can see here: https://industrialdigitaltwin.org/wp-content/uploads/2024/11/IDTA-02006-3-0_Submodel_Digital-Nameplate.pdf