### PR TITLE
chore: exclude docs from release trigger

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,8 +4,20 @@ on:
   push:
     branches: ['main', 'dev', 'staging']
     tags: ['v*.*.*']
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/CODEOWNERS'
+      - '.github/copilot-instructions.md'
+      - 'wiki/**'
+      - 'README.md'
   pull_request:
     branches: ['dev']
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/CODEOWNERS'
+      - '.github/copilot-instructions.md'
+      - 'wiki/**'
+      - 'README.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
# Description

The only thing left from improving the release process. Now docs fixes or README fixes can be pushed to main without triggering pipelines.

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix or my feature works
-   [x] New and existing tests pass locally with my changes
-   [x] My changes contain no console logs
