### PR TITLE
fix(rbac): roll back basyx versions

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -102,7 +102,7 @@ services:
       - mnestix-network
 
   aas-environment:
-    image: eclipsebasyx/aas-environment:2.0.0-milestone-05
+    image: eclipsebasyx/aas-environment:2.0.0-milestone-03.1
     container_name: aas-environment
     profiles: ['', 'basyx', 'tests']
     depends_on:
@@ -134,7 +134,7 @@ services:
       - mnestix-network
 
   aas-discovery:
-    image: eclipsebasyx/aas-discovery:2.0.0-milestone-05
+    image: eclipsebasyx/aas-discovery:2.0.0-milestone-03.1
     container_name: aas-discovery
     profiles: ['', 'basyx', 'tests']
     depends_on:
@@ -162,7 +162,7 @@ services:
       - mnestix-network
 
   aas-registry:
-    image: eclipsebasyx/aas-registry-log-mongodb:2.0.0-milestone-05
+    image: eclipsebasyx/aas-registry-log-mongodb:2.0.0-milestone-03.1
     container_name: aas-registry
     profiles: ['', 'basyx']
     ports:

--- a/docker-compose/compose.dynamic-rbac.yml
+++ b/docker-compose/compose.dynamic-rbac.yml
@@ -52,7 +52,7 @@ services:
         condition: service_completed_successfully
 
   security-submodel:
-    image: eclipsebasyx/submodel-repository:2.0.0-milestone-05
+    image: eclipsebasyx/submodel-repository:2.0.0-milestone-03.1
     container_name: security-submodel
     depends_on:
       keycloak:


### PR DESCRIPTION
# Description

As somewhere between the versions 03.1 and 05 Basyx seems to have introduced an issue that causes RBAC to not work correctly, this PR rolls back the versions to 03.1

## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

