### PR TITLE
fix(SubmodelOverviewCard): AAS view with no submodels shows a message with that information

### DIFF
--- a/src/app/[locale]/product/[base64AasId]/page.tsx
+++ b/src/app/[locale]/product/[base64AasId]/page.tsx
@@ -29,53 +29,61 @@ export default function Page() {
     const encodedRepoUrl = useSearchParams().get('repoUrl');
     const repoUrl = encodedRepoUrl ? decodeURI(encodedRepoUrl) : undefined;
     const [filteredSubmodels, setFilteredSubmodels] = useState<SubmodelOrIdReference[]>([]);
-    const [breadcrumbLinks] = useState<Array<{ label: string, path: string }>>([]);
+    const [breadcrumbLinks] = useState<Array<{ label: string; path: string }>>([]);
 
-
-    const {
-        aasFromContext,
-        isLoadingAas,
-        aasOriginUrl,
-        submodels,
-        isSubmodelsLoading,
-    } = useAasLoader(base64AasId, repoUrl);
+    const { aasFromContext, isLoadingAas, aasOriginUrl, submodels, isSubmodelsLoading } = useAasLoader(
+        base64AasId,
+        repoUrl,
+    );
 
     useEffect(() => {
         if (submodels) {
             const filtered = submodels.filter(
                 (submodel) =>
-                    !(checkIfSubmodelHasIdShortOrSemanticId(submodel, undefined, 'AasDesignerChangelog') ||
-                        checkIfSubmodelHasIdShortOrSemanticId(submodel, SubmodelSemanticIdEnum.NameplateV1, 'Nameplate') ||
-                        checkIfSubmodelHasIdShortOrSemanticId(submodel, SubmodelSemanticIdEnum.NameplateV2, 'Nameplate') ||
-                        checkIfSubmodelHasIdShortOrSemanticId(submodel, SubmodelSemanticIdEnum.NameplateV3, 'Nameplate') ||
-                        checkIfSubmodelHasIdShortOrSemanticId(submodel, SubmodelSemanticIdEnum.NameplateV4, 'Nameplate') ||
-                        checkIfSubmodelHasIdShortOrSemanticId(submodel, undefined, 'VEC_SML'))
+                    !(
+                        checkIfSubmodelHasIdShortOrSemanticId(submodel, undefined, 'AasDesignerChangelog') ||
+                        checkIfSubmodelHasIdShortOrSemanticId(
+                            submodel,
+                            SubmodelSemanticIdEnum.NameplateV1,
+                            'Nameplate',
+                        ) ||
+                        checkIfSubmodelHasIdShortOrSemanticId(
+                            submodel,
+                            SubmodelSemanticIdEnum.NameplateV2,
+                            'Nameplate',
+                        ) ||
+                        checkIfSubmodelHasIdShortOrSemanticId(
+                            submodel,
+                            SubmodelSemanticIdEnum.NameplateV3,
+                            'Nameplate',
+                        ) ||
+                        checkIfSubmodelHasIdShortOrSemanticId(
+                            submodel,
+                            SubmodelSemanticIdEnum.NameplateV4,
+                            'Nameplate',
+                        ) ||
+                        checkIfSubmodelHasIdShortOrSemanticId(submodel, undefined, 'VEC_SML')
+                    ),
             );
             setFilteredSubmodels(filtered);
         }
     }, [submodels]);
 
-    const nameplate = findSubmodelByIdOrSemanticId(
-        submodels,
-        SubmodelSemanticIdEnum.NameplateV2,
-        'Nameplate',
-    );
+    const nameplate = findSubmodelByIdOrSemanticId(submodels, SubmodelSemanticIdEnum.NameplateV2, 'Nameplate');
 
     if (nameplate) {
         const productBreadcrumbProperties = [
             { idShort: 'ManufacturerProductRoot', semanticId: SubmodelElementSemanticIdEnum.ManufacturerProductRoot },
-            { idShort: 'ManufacturerProductFamily', semanticId: SubmodelElementSemanticIdEnum.ManufacturerProductFamily },
-            { idShort: 'ManufacturerProductType', semanticId: SubmodelElementSemanticIdEnum.ManufacturerProductType }
+            {
+                idShort: 'ManufacturerProductFamily',
+                semanticId: SubmodelElementSemanticIdEnum.ManufacturerProductFamily,
+            },
+            { idShort: 'ManufacturerProductType', semanticId: SubmodelElementSemanticIdEnum.ManufacturerProductType },
         ];
 
-        productBreadcrumbProperties.forEach(prop => {
-            const value = findValueByIdShort(
-                nameplate.submodelElements,
-                prop.idShort,
-                prop.semanticId,
-                locale,
-            );
-            if (value && !breadcrumbLinks.some(link => link.label === value)) {
+        productBreadcrumbProperties.forEach((prop) => {
+            const value = findValueByIdShort(nameplate.submodelElements, prop.idShort, prop.semanticId, locale);
+            if (value && !breadcrumbLinks.some((link) => link.label === value)) {
                 breadcrumbLinks.push({
                     label: value,
                     path: '',
@@ -116,11 +124,16 @@ export default function Page() {
                         isLoading={isLoadingAas || isSubmodelsLoading}
                         isAccordion={isMobile}
                         repositoryURL={aasOriginUrl}
-                        displayName={aasFromContext?.displayName ? getTranslationText(aasFromContext.displayName, locale) : null}
+                        displayName={
+                            aasFromContext?.displayName ? getTranslationText(aasFromContext.displayName, locale) : null
+                        }
                     />
-                    {aasFromContext?.submodels && aasFromContext.submodels.length > 0 && (
-                        <SubmodelsOverviewCard submodelIds={filteredSubmodels} submodelsLoading={isSubmodelsLoading} firstSubmodelIdShort="TechnicalData" disableHeadline={true} />
-                    )}
+                    <SubmodelsOverviewCard
+                        submodelIds={filteredSubmodels}
+                        submodelsLoading={isSubmodelsLoading}
+                        firstSubmodelIdShort="TechnicalData"
+                        disableHeadline={true}
+                    />
                 </Box>
             ) : (
                 <NoSearchResult base64AasId={safeBase64Decode(base64AasId)} />

--- a/src/app/[locale]/viewer/[base64AasId]/page.tsx
+++ b/src/app/[locale]/viewer/[base64AasId]/page.tsx
@@ -25,13 +25,10 @@ export default function Page() {
     const repoUrl = encodedRepoUrl ? decodeURI(encodedRepoUrl) : undefined;
     const t = useTranslations('pages.aasViewer');
 
-    const {
-        aasFromContext,
-        isLoadingAas,
-        aasOriginUrl,
-        submodels,
-        isSubmodelsLoading,
-    } = useAasLoader(base64AasId, repoUrl);
+    const { aasFromContext, isLoadingAas, aasOriginUrl, submodels, isSubmodelsLoading } = useAasLoader(
+        base64AasId,
+        repoUrl,
+    );
 
     const startComparison = () => {
         navigate.push(`/compare?aasId=${encodeURIComponent(aasIdDecoded)}`);
@@ -96,11 +93,11 @@ export default function Page() {
                             </Button>
                         )}
                         {env.TRANSFER_FEATURE_FLAG && <TransferButton />}
-                        {env.PRODUCT_VIEW_FEATURE_FLAG &&
+                        {env.PRODUCT_VIEW_FEATURE_FLAG && (
                             <Button variant="contained" sx={{ whiteSpace: 'nowrap' }} onClick={goToProductView}>
                                 {t('actions.toProductView')}
                             </Button>
-                        }
+                        )}
                     </Box>
                     <AASOverviewCard
                         aas={aasFromContext ?? null}
@@ -109,9 +106,7 @@ export default function Page() {
                         isAccordion={isMobile}
                         repositoryURL={aasOriginUrl}
                     />
-                    {aasFromContext?.submodels && aasFromContext.submodels.length > 0 && (
-                        <SubmodelsOverviewCard submodelIds={submodels} submodelsLoading={isSubmodelsLoading} />
-                    )}
+                    <SubmodelsOverviewCard submodelIds={submodels} submodelsLoading={isSubmodelsLoading} />
                 </Box>
             ) : (
                 <NoSearchResult base64AasId={safeBase64Decode(base64AasId)} />

--- a/src/app/[locale]/viewer/_components/SubmodelsOverviewCard.tsx
+++ b/src/app/[locale]/viewer/_components/SubmodelsOverviewCard.tsx
@@ -19,7 +19,12 @@ export type SubmodelsOverviewCardProps = {
     readonly disableHeadline?: boolean;
 };
 
-export function SubmodelsOverviewCard({ submodelIds, submodelsLoading, firstSubmodelIdShort, disableHeadline }: SubmodelsOverviewCardProps) {
+export function SubmodelsOverviewCard({
+    submodelIds,
+    submodelsLoading,
+    firstSubmodelIdShort,
+    disableHeadline,
+}: SubmodelsOverviewCardProps) {
     const [submodelSelectorItems, setSubmodelSelectorItems] = useState<TabSelectorItem[]>([]);
     const [selectedItem, setSelectedItem] = useState<TabSelectorItem>();
     const t = useTranslations('pages.aasViewer.submodels');
@@ -67,13 +72,15 @@ export function SubmodelsOverviewCard({ submodelIds, submodelsLoading, firstSubm
     }, [submodelIds]);
 
     useEffect(() => {
-        const nameplateTab = submodelSelectorItems.find((tab) => tab.submodelData?.idShort === firstSubmodelToShowIdShort);
+        const nameplateTab = submodelSelectorItems.find(
+            (tab) => tab.submodelData?.idShort === firstSubmodelToShowIdShort,
+        );
         if (!selectedItem && !isMobile && nameplateTab) {
             setSelectedItem(nameplateTab);
         }
     }, [isMobile, submodelSelectorItems]);
 
-    const SelectedContent = useMemo(() =>  {
+    const SelectedContent = useMemo(() => {
         if (selectedItem?.submodelData && !submodelsLoading) {
             return (
                 <ErrorBoundary message={t('renderError')}>
@@ -101,37 +108,51 @@ export function SubmodelsOverviewCard({ submodelIds, submodelsLoading, firstSubm
         <>
             <Card>
                 <CardContent>
-                    { !disableHeadline && (
+                    {!disableHeadline && (
                         <Typography variant="h3" marginBottom="15px">
                             {t('title')}
                         </Typography>
                     )}
-                    <Box display="grid" gridTemplateColumns={isMobile ? '1fr' : '1fr 2fr'} gap="2rem">
-                        <Box>
-                            <VerticalTabSelector
-                                items={submodelSelectorItems}
-                                selected={selectedItem}
-                                setSelected={setSelectedItem}
-                                setInfoItem={setInfoItem}
-                            />
-                            {submodelsLoading && (
-                                <Skeleton height={70} sx={{ mb: 2 }} data-testid="submodelOverviewLoadingSkeleton" />
+                    {getSubmodelTabs().length == 0 ? (
+                        // Content if there are no submodels to load
+                        <Box display="flex" justifyContent="center" alignItems="center" height="100%">
+                            <Typography variant={'body1'} color="text.secondary">
+                                {t('noSubmodelsToLoad')}
+                            </Typography>
+                        </Box>
+                    ) : (
+                        // Content if there are submodels
+                        <Box display="grid" gridTemplateColumns={isMobile ? '1fr' : '1fr 2fr'} gap="2rem">
+                            <Box>
+                                <VerticalTabSelector
+                                    items={submodelSelectorItems}
+                                    selected={selectedItem}
+                                    setSelected={setSelectedItem}
+                                    setInfoItem={setInfoItem}
+                                />
+                                {submodelsLoading && (
+                                    <Skeleton
+                                        height={70}
+                                        sx={{ mb: 2 }}
+                                        data-testid="submodelOverviewLoadingSkeleton"
+                                    />
+                                )}
+                            </Box>
+                            {isMobile ? (
+                                <MobileModal
+                                    selectedItem={selectedItem}
+                                    open={!!selectedItem}
+                                    handleClose={() => {
+                                        setSelectedItem(undefined);
+                                    }}
+                                    setInfoItem={setInfoItem}
+                                    content={SelectedContent}
+                                />
+                            ) : (
+                                SelectedContent
                             )}
                         </Box>
-                        {isMobile ? (
-                            <MobileModal
-                                selectedItem={selectedItem}
-                                open={!!selectedItem}
-                                handleClose={() => {
-                                    setSelectedItem(undefined);
-                                }}
-                                setInfoItem={setInfoItem}
-                                content={SelectedContent}
-                            />
-                        ) : (
-                            SelectedContent
-                        )}
-                    </Box>
+                    )}
                 </CardContent>
             </Card>
 

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -249,7 +249,8 @@
           "selectTimeframe": "Auswahl des Zeitabschnitts"
         },
         "title": "Teilmodelle",
-        "unknownModelType": "Unbekannter ModelType: {type}"
+        "unknownModelType": "Unbekannter ModelType: {type}",
+        "noSubmodelsToLoad": "Für diese AAS existieren keine Teilmodelle."
       }
     },
     "catalog": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -249,7 +249,8 @@
           "selectTimeframe": "Select timeframe"
         },
         "title": "Submodels",
-        "unknownModelType": "Unknown ModelType: {type}"
+        "unknownModelType": "Unknown ModelType: {type}",
+        "noSubmodelsToLoad": "There do not exist any submodels for this AAS."
       }
     },
     "catalog": {

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -249,7 +249,8 @@
           "selectTimeframe": "Seleccionar periodo de tiempo"
         },
         "title": "Submodels",
-        "unknownModelType": "ModelType desconocido: {type}"
+        "unknownModelType": "ModelType desconocido: {type}",
+        "noSubmodelsToLoad": "No existen submodels que cargar para este AAS."
       }
     },
     "catalog": {


### PR DESCRIPTION
# Description

This PR changes the visualization of the AAS when there is **no submodels** on that AAS.

Before the change, the card that showed the submodels did not appear, potentially producing the misconception that the submodels were loading still when the truth is that there is no submodels associated with that AAS.

Now, the card of the submodels appear and shows a message telling the user there are no submodels to load for that AAS, solving the potential misunderstanding.

It a**lso updates the Product page** so the behavior is consistent in viewer and in product pages.

## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [x] New and existing tests pass locally with my changes
-   [x] My changes contain no console logs
