### PR TITLE
fix(submodelDetail): find submodelVisualization when more than 1 semanticId

### DIFF
--- a/src/app/[locale]/viewer/_components/submodel/SubmodelDetail.spec.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/SubmodelDetail.spec.tsx
@@ -30,20 +30,41 @@ jest.mock('next-auth', jest.fn());
 
 describe('Submodel Detail', () => {
     it('should render CarbonFootprintVisualizations for irdi id', async () => {
-        CustomRender(
-            <SubmodelDetail submodel={testSubmodel['carbonFootprint-IrdiId'] as unknown as Submodel} />,
-        );
+        CustomRender(<SubmodelDetail submodel={testSubmodel['carbonFootprint-IrdiId'] as unknown as Submodel} />);
         const map = screen.getByTestId('carbonFootprintVisualizations');
         expect(map).toBeDefined();
         expect(map).toBeInTheDocument();
     });
 
     it('should render CarbonFootprintVisualizations for URL id', async () => {
-        CustomRender(
-            <SubmodelDetail submodel={testSubmodel['carbonFootprint-UrlId'] as unknown as Submodel} />,
-        );
+        CustomRender(<SubmodelDetail submodel={testSubmodel['carbonFootprint-UrlId'] as unknown as Submodel} />);
         const map = screen.getByTestId('carbonFootprintVisualizations');
         expect(map).toBeDefined();
         expect(map).toBeInTheDocument();
+    });
+
+    it('should use third semanticId when first two are invalid', async () => {
+        // Create test submodel with multiple semanticIds (first two invalid)
+        const testSubmodelWithMultipleIds = {
+            ...testSubmodel['carbonFootprint-UrlId'],
+            semanticId: {
+                keys: [
+                    { value: 'invalid-semantic-id-1' },
+                    { value: 'invalid-semantic-id-2' },
+                    { value: 'https://admin-shell.io/idta/CarbonFootprint/CarbonFootprint/0/9' }, // Valid CarbonFootprint ID
+                ],
+            },
+        } as unknown as Submodel;
+
+        CustomRender(<SubmodelDetail submodel={testSubmodelWithMultipleIds} />);
+
+        // Verify visualization component renders using 3rd semanticId
+        const map = screen.getByTestId('carbonFootprintVisualizations');
+        expect(map).toBeDefined();
+        expect(map).toBeInTheDocument();
+
+        // Verify no error state for invalid IDs
+        expect(screen.queryByTestId('invalid-semantic-id-1')).toBeNull();
+        expect(screen.queryByTestId('invalid-semantic-id-2')).toBeNull();
     });
 });

--- a/src/app/[locale]/viewer/_components/submodel/SubmodelDetail.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/SubmodelDetail.tsx
@@ -2,7 +2,7 @@ import { Submodel } from '@aas-core-works/aas-core3.0-typescript/types';
 import { submodelCustomVisualizationMap } from './SubmodelCustomVisualizationMap';
 import { GenericSubmodelDetailComponent } from './generic-submodel/GenericSubmodelDetailComponent';
 import { Box } from '@mui/material';
-import { idEquals } from 'lib/util/IdValidationUtil';
+import { findSemanticIdInMap } from 'lib/util/SubmodelResolverUtil';
 
 type SubmodelDetailProps = {
     submodel?: Submodel;
@@ -12,12 +12,7 @@ export function SubmodelDetail(props: SubmodelDetailProps) {
     const submodelElements = props.submodel?.submodelElements;
     if (!props.submodel || !submodelElements) return <></>;
 
-    const semanticId = props.submodel.semanticId?.keys?.[0]?.value;
-
-    // We have to use the idEquals function here to correctly handle IRDIs
-    const key = Object.keys(submodelCustomVisualizationMap).find((key) => idEquals(semanticId, key)) as
-        | keyof typeof submodelCustomVisualizationMap
-        | undefined;
+    const key = findSemanticIdInMap(props.submodel.semanticId, submodelCustomVisualizationMap);
 
     const CustomSubmodelComponent = key ? submodelCustomVisualizationMap[key] : undefined;
 

--- a/src/lib/util/SubmodelResolverUtil.ts
+++ b/src/lib/util/SubmodelResolverUtil.ts
@@ -8,6 +8,7 @@ import {
     SubmodelElementCollection,
     KeyTypes,
     IDataElement,
+    Reference,
 } from '@aas-core-works/aas-core3.0-typescript/types';
 import { idEquals } from './IdValidationUtil';
 import { getKeyType } from 'lib/util/KeyTypeUtil';
@@ -71,12 +72,19 @@ export function findSubmodelElementBySemanticIdsOrIdShort(
     semanticIds: string[] | null,
 ): ISubmodelElement | null {
     if (!elements) return null;
-    return elements?.find(el =>
-        el.idShort == idShort ||
-        (semanticIds?.some(semId => idEquals(el.semanticId?.keys[0]?.value.trim(), semId.trim()))) ||
-        (getKeyType(el) == KeyTypes.SubmodelElementCollection &&
-            findSubmodelElementBySemanticIdsOrIdShort((el as SubmodelElementCollection).value, idShort, semanticIds))
-    ) ?? null;
+    return (
+        elements?.find(
+            (el) =>
+                el.idShort == idShort ||
+                semanticIds?.some((semId) => idEquals(el.semanticId?.keys[0]?.value.trim(), semId.trim())) ||
+                (getKeyType(el) == KeyTypes.SubmodelElementCollection &&
+                    findSubmodelElementBySemanticIdsOrIdShort(
+                        (el as SubmodelElementCollection).value,
+                        idShort,
+                        semanticIds,
+                    )),
+        ) ?? null
+    );
 }
 
 export function findAllSubmodelElementsBySemanticIdsOrIdShort(
@@ -85,12 +93,19 @@ export function findAllSubmodelElementsBySemanticIdsOrIdShort(
     semanticIds: string[] | null,
 ): ISubmodelElement[] | null {
     if (!elements) return null;
-    return elements?.filter(el =>
-        el.idShort == idShort ||
-        (semanticIds?.some(semId => idEquals(el.semanticId?.keys[0]?.value.trim(), semId.trim()))) ||
-        (getKeyType(el) == KeyTypes.SubmodelElementCollection &&
-            findSubmodelElementBySemanticIdsOrIdShort((el as SubmodelElementCollection).value, idShort, semanticIds))
-    ) ?? null;
+    return (
+        elements?.filter(
+            (el) =>
+                el.idShort == idShort ||
+                semanticIds?.some((semId) => idEquals(el.semanticId?.keys[0]?.value.trim(), semId.trim())) ||
+                (getKeyType(el) == KeyTypes.SubmodelElementCollection &&
+                    findSubmodelElementBySemanticIdsOrIdShort(
+                        (el as SubmodelElementCollection).value,
+                        idShort,
+                        semanticIds,
+                    )),
+        ) ?? null
+    );
 }
 
 export function findValueByIdShort(
@@ -184,4 +199,22 @@ export function checkIfSubmodelHasIdShortOrSemanticId(
         (submodel.submodel?.semanticId?.keys?.length && submodel.submodel?.semanticId?.keys[0].value === semanticId) ||
         submodel.submodel?.idShort === idShort
     );
+}
+
+/**
+ * Finds the first semantic ID key in the given submodel semanticId that matches a key in the [visualization] map.
+ *
+ * @param semanticId - The reference object containing semantic ID keys to search.
+ * @param map - The semanticIds map to check against the possible semanticIds
+ *
+ * @returns The string of the matching semanticId key as a key of `submodelCustomVisualizationMap`, or `undefined` if no match is found.
+ */
+export function findSemanticIdInMap<T extends Record<string, string | ((...args: unknown[]) => unknown)>>(
+    semanticId: Reference | null | undefined,
+    map: T,
+): keyof T | undefined {
+    // We have to use the idEquals function here to correctly handle IRDIs
+    return Object.keys(map).find((mapKey) => semanticId?.keys?.some((id) => idEquals(id.value, mapKey))) as
+        | keyof T
+        | undefined;
 }


### PR DESCRIPTION
# Description

This PR includes code to look for a submodel visualization when the `semanticId?.keys` contains more than 1 key in position [0]. So a special visualization can be recovered if available for the submodel. To this end:

- Generic function `findSemanticIdInMap` added to `submodelResolverUtils`. This function can be reused to find the semantic id key of any map (future potential use to replace all the `submodel?.semanticId?.keys?[0].value` statements that only check the first entry of the semanticId keys.

- Uses this function to recover submodel visualization in `SubmodelDetail.ts`.

- Implemented a new test for `SubmodelDetail` to check that it identifies the correct visualization even when more than 1 semanticId key,


## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix or my feature works
-   [x] New and existing tests pass locally with my changes
-   [x] My changes contain no console logs
