### PR TITLE
Fix/rbac submodel service

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -102,7 +102,7 @@ services:
       - mnestix-network
 
   aas-environment:
-    image: eclipsebasyx/aas-environment:2.0.0-milestone-05.1
+    image: eclipsebasyx/aas-environment:2.0.0-milestone-06
     container_name: aas-environment
     profiles: ['', 'basyx', 'tests']
     depends_on:
@@ -134,7 +134,7 @@ services:
       - mnestix-network
 
   aas-discovery:
-    image: eclipsebasyx/aas-discovery:2.0.0-milestone-05.1
+    image: eclipsebasyx/aas-discovery:2.0.0-milestone-06
     container_name: aas-discovery
     profiles: ['', 'basyx', 'tests']
     depends_on:
@@ -162,7 +162,7 @@ services:
       - mnestix-network
 
   aas-registry:
-    image: eclipsebasyx/aas-registry-log-mongodb:2.0.0-milestone-05.1
+    image: eclipsebasyx/aas-registry-log-mongodb:2.0.0-milestone-06
     container_name: aas-registry
     profiles: ['', 'basyx']
     ports:
@@ -182,7 +182,7 @@ services:
       - mnestix-network
 
   submodel-registry:
-    image: eclipsebasyx/submodel-registry-log-mongodb:2.0.0-milestone-05.1
+    image: eclipsebasyx/submodel-registry-log-mongodb:2.0.0-milestone-06
     container_name: submodel-registry
     profiles: ['', 'basyx']
     ports:


### PR DESCRIPTION
# Description

As reported in https://github.com/eclipse-basyx/basyx-java-server-sdk/issues/778 BaSyx change the package of the SubmodelTargetInformation that's why Dynamic RBAC didn't work anymore.

Milestone 6 also release 3 hours ago so updated to that so we don't have the same situation next month.

Fixes https://xitaso.atlassian.net/browse/MNE-179

![image](https://github.com/user-attachments/assets/b61b961b-61a5-4c0d-92bd-712061e3e0d6)


# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix or my feature works
-   [x] New and existing tests pass locally with my changes
-   [x] My changes contain no console logs
