### PR TITLE
removed eclass hierarchy and show link to documentation instead

### DIFF
--- a/src/app/[locale]/marketplace/catalog/_components/EClassFilter.tsx
+++ b/src/app/[locale]/marketplace/catalog/_components/EClassFilter.tsx
@@ -1,14 +1,19 @@
 import { SimpleTreeView, TreeItem } from '@mui/x-tree-view';
-import { Box, Checkbox, Typography } from '@mui/material';
+import { Box, Checkbox, IconButton, Tooltip, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { FilterQuery } from 'app/[locale]/marketplace/catalog/_components/FilterContainer';
+import OpenInNew from '@mui/icons-material/OpenInNew';
 import { useTranslations } from 'next-intl';
 
 export interface CheckboxFilterState {
     [key: string]: boolean;
 }
 
-export function EClassFilter(props: { eClassFilters: string[]; onFilterChanged(query: FilterQuery[]): void; resetFilters: boolean }) {
+export function EClassFilter(props: {
+    eClassFilters: string[];
+    onFilterChanged(query: FilterQuery[]): void;
+    resetFilters: boolean;
+}) {
     const t = useTranslations('pages.catalog');
     const [selectedFilters, setSelectedFilters] = useState<CheckboxFilterState>(() => {
         const initialState: CheckboxFilterState = {};
@@ -42,75 +47,9 @@ export function EClassFilter(props: { eClassFilters: string[]; onFilterChanged(q
         }));
     }
 
-    function onGroupFilterChange(eClasses: string[], checked: boolean) {
-        setSelectedFilters((prevState) => {
-            const updatedFilters = { ...prevState };
-            eClasses.forEach((eClass) => {
-                updatedFilters[eClass] = checked;
-            });
-            return updatedFilters;
-        });
-    }
+    const eClassUrl = (eClass: string) =>
+        `https://eclass.eu/eclass-standard/content-suche/show?tx_eclasssearch_ecsearch%5Bdischarge%5D=0&tx_eclasssearch_ecsearch%5Bid%5D=${eClass.replaceAll('-', '')}&tx_eclasssearch_ecsearch%5Blanguage%5D=0`;
 
-    const resolveEclassLabel = (eClass: string) => {
-        switch (eClass) {
-            case '15':
-                return t('eclassCategories.15');
-            case '27':
-                return t('eclassCategories.27');
-            case '44':
-                return t('eclassCategories.44');
-            default:
-                return t('eclassCategories.default') + eClass;
-        }
-    };
-
-    function prepareEclassHierarchy(eClassFilters: string[]) {
-        const groupedFilters = eClassFilters.reduce(
-            (acc, eClass) => {
-                const group = eClass.slice(0, 2);
-                if (!acc[group]) {
-                    acc[group] = [];
-                }
-                acc[group].push(eClass);
-                return acc;
-            },
-            {} as Record<string, string[]>,
-        );
-
-        return Object.entries(groupedFilters).map(([group, eClasses]) => {
-            const isGroupChecked = eClasses.every((eClass) => selectedFilters[eClass]);
-            return (
-                <TreeItem
-                    key={group}
-                    itemId={group}
-                    label={
-                        <Box display="flex" alignItems="center">
-                            <Checkbox
-                                checked={isGroupChecked}
-                                indeterminate={eClasses.some((eClass) => selectedFilters[eClass]) && !isGroupChecked}
-                                onChange={(event) => onGroupFilterChange(eClasses, event.target.checked)}
-                                onClick={(event) => event.stopPropagation()}
-                                sx={{ padding: '4px' }}
-                            />
-                            {resolveEclassLabel(group)}
-                        </Box>
-                    }
-                >
-                    {eClasses.map((eClass) => (
-                        <Box key={eClass} display="flex" alignItems="center" ml={4}>
-                            <Checkbox
-                                checked={selectedFilters[eClass] || false}
-                                onChange={(event) => onFilterChange(eClass, event.target.checked)}
-                                sx={{ padding: '6px' }}
-                            />
-                            <Typography>{eClass}</Typography>
-                        </Box>
-                    ))}
-                </TreeItem>
-            );
-        });
-    }
     return (
         <SimpleTreeView>
             <TreeItem
@@ -121,7 +60,21 @@ export function EClassFilter(props: { eClassFilters: string[]; onFilterChanged(q
                     </Typography>
                 }
             >
-                {prepareEclassHierarchy(props.eClassFilters)}
+                {props.eClassFilters.map((eClass) => (
+                    <Box key={eClass} display="flex" alignItems="center">
+                        <Checkbox
+                            checked={selectedFilters[eClass] || false}
+                            onChange={(event) => onFilterChange(eClass, event.target.checked)}
+                            sx={{ padding: '6px' }}
+                        />
+                        <Typography>{eClass}</Typography>
+                        <Tooltip title={t('eclassDocumentationLink')}>
+                            <IconButton href={eClassUrl(eClass)} target="_blank">
+                                <OpenInNew />
+                            </IconButton>
+                        </Tooltip>
+                    </Box>
+                ))}
             </TreeItem>
         </SimpleTreeView>
     );

--- a/src/app/[locale]/marketplace/catalog/page.tsx
+++ b/src/app/[locale]/marketplace/catalog/page.tsx
@@ -130,32 +130,30 @@ export default function Page() {
                 )}
             </Box>
             <Box display="flex" flexDirection="row" marginBottom="1.5rem">
-                <Card
-                    sx={{
-                        minHeight: 480,
-                        minWidth: 250,
-                        maxWidth: 340,
-                        marginBottom: 'auto',
-                        p: 2,
-                        boxShadow: 1,
-                        borderRadius: 1,
-                        mr: 3,
-                    }}
-                    aria-label={t('filter')}
-                >
-                    {!fallbackToAasList && connection && connection.aasSearcher ? (
-                        <FilterContainer onFilterChanged={onFilterChanged} aasSearcherUrl={connection.aasSearcher} />
-                    ) : loading ? (
-                        <CenteredLoadingSpinner />
-                    ) : (
-                        <Box>
-                            <Typography variant="h4" fontWeight={600} mb={1}>
-                                {t('filter')}
-                            </Typography>
-                            <Typography mt={2}>{t('noSearcherWarning')}</Typography>
-                        </Box>
-                    )}
-                </Card>
+                {!fallbackToAasList && connection && connection.aasSearcher && (
+                    <Card
+                        sx={{
+                            minHeight: 480,
+                            minWidth: 250,
+                            maxWidth: 340,
+                            marginBottom: 'auto',
+                            p: 2,
+                            boxShadow: 1,
+                            borderRadius: 1,
+                            mr: 3,
+                        }}
+                        aria-label={t('filter')}
+                    >
+                        {loading ? (
+                            <CenteredLoadingSpinner />
+                        ) : (
+                            <FilterContainer
+                                onFilterChanged={onFilterChanged}
+                                aasSearcherUrl={connection?.aasSearcher}
+                            />
+                        )}
+                    </Card>
+                )}
                 <Box flex={1} minWidth={0}>
                     {loading ? (
                         <CenteredLoadingSpinner />
@@ -169,6 +167,7 @@ export default function Page() {
                         </Card>
                     ) : (
                         <Box>
+                            <Typography variant="body1" color="textSecondary" mb={2}>{t('noSearcherWarning')}</Typography>
                             <AasListDataWrapper repositoryUrl={repositoryUrl} hideRepoSelection={true} />
                         </Box>
                     )}

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -262,12 +262,7 @@
       "articleCount": "{count, plural, =1 {# Artikel} other {# Artikel}}",
       "filter": "Filter",
       "noSearcherWarning": "Kein AAS Searcher konfiguriert. AAS Liste wird angezeigt, Filterung ist nicht möglich.",
-      "eclassCategories": {
-        "15": "Instandhaltung (Dienstleistung)",
-        "27": "Elektro-, Automatisierungs- und Prozessleittechnik",
-        "44": "Fahrzeugtechnik, Fahrzeugkomponente",
-        "default": "Kategorie "
-      },
+      "eclassDocumentationLink": "In ECLASS Dokumentation nachlesen",
       "searchPlaceholder": "Suche aktuell nicht verfügbar..."
     },
     "compare": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -262,12 +262,7 @@
       "articleCount": "{count, plural, =1 {# article} other {# articles}}",
       "filter": "Filter",
       "noSearcherWarning": "No AAS Searcher Configured. Showing AAS List as Fallback, filters won't work.",
-      "eclassCategories": {
-        "15": "Maintenance (Service)",
-        "27": "Electric engineering, automation, process control engineering ",
-        "44": "Automotive engineering, vehicle component",
-        "default": "Category "
-      },
+      "eclassDocumentationLink": "Open in ECLASS documentation",
       "searchPlaceholder": "Search currently unavailable..."
     },
     "compare": {

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -262,12 +262,7 @@
       "articleCount": "{count, plural, =1 {# artículo} other {# artículos}}",
       "filter": "Filtro",
       "noSearcherWarning": "No se ha configurado el buscador AAS - Se muestra la lista AAS",
-      "eclassCategories": {
-        "15": "Maintenance (Service)",
-        "27": "Electric engineering, automation, process control engineering ",
-        "44": "Automotive engineering, vehicle component",
-        "default": "Category "
-      },
+      "eclassDocumentationLink": "Abrir en la documentación de ECLASS",
       "searchPlaceholder": "Búsqueda no disponible actualmente..."
     },
     "compare": {


### PR DESCRIPTION
# Description

removed eclass hierarchy from filter and added link to the documentation
filter box is not shown when there are no filters

## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
