### PR TITLE
feat(product view): Add URI next to product name

### DIFF
--- a/src/app/[locale]/product/_components/ProductOverviewCard.tsx
+++ b/src/app/[locale]/product/_components/ProductOverviewCard.tsx
@@ -55,7 +55,7 @@ type OverviewData = {
     readonly companyLogo: ISubmodelElement | null;
     readonly markings: string[] | null;
     readonly productClassifications?: ProductClassification[];
-    readonly URIOfTheProduct?: string;
+    readonly URIOfTheProduct?: string | null;
 };
 
 export function ProductOverviewCard(props: ProductOverviewCardProps) {
@@ -184,8 +184,8 @@ export function ProductOverviewCard(props: ProductOverviewCardProps) {
 
         const URIOfTheProduct = findValue(
             nameplateSubmodelElements,
-            'URIOfTheProduct',
-            SubmodelElementSemanticIdEnum.URIOfTheProduct
+            'URIOfTheProducts',
+            [SubmodelElementSemanticIdEnum.URIOfTheProductV2, SubmodelElementSemanticIdEnum.URIOfTheProductV3]
         );
 
         setOverviewData((prevData) => ({
@@ -196,7 +196,7 @@ export function ProductOverviewCard(props: ProductOverviewCardProps) {
             markings: markings,
             manufacturerLogo: prevData?.manufacturerLogo || null,
             companyLogo: companyLogo || null,
-            URIOfTheProduct:  URIOfTheProduct || undefined
+            URIOfTheProduct:  URIOfTheProduct || null
         }));
     };
 

--- a/src/lib/enums/SubmodelElementSemanticId.enum.ts
+++ b/src/lib/enums/SubmodelElementSemanticId.enum.ts
@@ -24,5 +24,6 @@ export enum SubmodelElementSemanticIdEnum {
     ProductClassificationSystem = 'https://admin-shell.io/ZVEI/TechnicalData/ProductClassificationSystem/1/1',
     TechnicalProperties = 'https://admin-shell.io/ZVEI/TechnicalData/TechnicalProperties/1/1',
     FurtherInformation = 'https://admin-shell.io/ZVEI/TechnicalData/FurtherInformation/1/1',
-    URIOfTheProduct = '0112/2///61987#ABN590#002'
+    URIOfTheProductV2 = '0173-1#02-AAY811#001',
+    URIOfTheProductV3 = '0112/2///61987#ABN590#002',
 }

--- a/src/lib/hooks/useFindValueByIdShort.ts
+++ b/src/lib/hooks/useFindValueByIdShort.ts
@@ -18,9 +18,18 @@ export function useFindValueByIdShort() {
         (
             elements: ISubmodelElement[] | null,
             idShort: string | null,
-            semanticId: SubmodelSemanticIdEnum | SubmodelElementSemanticIdEnum | null = null,
+            semanticId: SubmodelSemanticIdEnum | SubmodelElementSemanticIdEnum | SubmodelSemanticIdEnum[] | SubmodelElementSemanticIdEnum[] | null = null,
         ): string | null => {
-            return findValueByIdShort(elements, idShort, semanticId, locale);
+            if (semanticId && !Array.isArray(semanticId)) {
+                return findValueByIdShort(elements, idShort, semanticId, locale);
+            }
+            else if (Array.isArray(semanticId)) {
+                return semanticId.reduce((acc, id) => {
+                    const value = findValueByIdShort(elements, idShort, id, locale);
+                    return acc || value;
+                }, null);
+            }
+            return findValueByIdShort(elements, idShort, null, locale);
         },
         [locale]
     );


### PR DESCRIPTION
This pull request introduces functionality to display and navigate to a product's URI in the `ProductOverviewCard` component. It also enhances the `useFindValueByIdShort` hook to support multiple semantic IDs. Below are the most important changes grouped by theme:

### New Functionality in `ProductOverviewCard`

* Added a new optional property `URIOfTheProduct` to the `OverviewData` type, allowing the component to store and display the product's URI. ([src/app/[locale]/product/_components/ProductOverviewCard.tsxR58](diffhunk://#diff-ef1cf4be9ab35b85fd69db745e9a551c1216c887b78c8894e1e94bbddf916ff7R58), [src/app/[locale]/product/_components/ProductOverviewCard.tsxR199](diffhunk://#diff-ef1cf4be9ab35b85fd69db745e9a551c1216c887b78c8894e1e94bbddf916ff7R199))
* Introduced a `navigateToProduct` function that redirects users to the product's URI when triggered. ([src/app/[locale]/product/_components/ProductOverviewCard.tsxR250-R256](diffhunk://#diff-ef1cf4be9ab35b85fd69db745e9a551c1216c887b78c8894e1e94bbddf916ff7R250-R256))
* Updated the UI to include a clickable `LinkIcon` with a tooltip showing the product's URI. The icon is displayed only if the `URIOfTheProduct` is available. ([src/app/[locale]/product/_components/ProductOverviewCard.tsxR402-R412](diffhunk://#diff-ef1cf4be9ab35b85fd69db745e9a551c1216c887b78c8894e1e94bbddf916ff7R402-R412))

### Enhancements to Semantic ID Handling

* Extended the `useFindValueByIdShort` hook to accept arrays of semantic IDs, enabling it to search for a value across multiple semantic IDs.

### Updates to Enumerations

* Added two new semantic IDs, `URIOfTheProductV2` and `URIOfTheProductV3`, to the `SubmodelElementSemanticIdEnum` for identifying product URIs.

### Dependency Updates

* Imported `Tooltip` and `LinkIcon` from `@mui/material` and `@mui/icons-material`, respectively, to support the new UI features. ([src/app/[locale]/product/_components/ProductOverviewCard.tsxL1-R1](diffhunk://#diff-ef1cf4be9ab35b85fd69db745e9a551c1216c887b78c8894e1e94bbddf916ff7L1-R1), [src/app/[locale]/product/_components/ProductOverviewCard.tsxR28](diffhunk://#diff-ef1cf4be9ab35b85fd69db745e9a551c1216c887b78c8894e1e94bbddf916ff7R28))