### PR TITLE
fix(Page): ensure breadcrumbs loading state is updated correctly

### DIFF
--- a/src/app/[locale]/product/[base64AasId]/page.tsx
+++ b/src/app/[locale]/product/[base64AasId]/page.tsx
@@ -161,10 +161,10 @@ export default function Page() {
                         });
                     }
                 });
-                setIsBreadcrumbsLoading(false);
             }
 
             setBreadcrumbLinks(newBreadcrumbLinks);
+            setIsBreadcrumbsLoading(false);
         };
         
         fetchManufacturerData();


### PR DESCRIPTION
This pull request includes a minor change to the `Page` component in `src/app/[locale]/product/[base64AasId]/page.tsx`. The change reorders the call to `setIsBreadcrumbsLoading(false)` to ensure it is executed after `setBreadcrumbLinks` for better readability and logical flow. ([src/app/[locale]/product/[base64AasId]/page.tsxL164-R167](diffhunk://#diff-ccee45e0b50344c81e3a4f06db382e7df1442951aac8bcc0148354cdd5cfe882L164-R167))