### PR TITLE
feat(ProductOverviewCard): open product URL in a new tab when navigating

### DIFF
--- a/src/app/[locale]/product/_components/ProductOverviewCard.tsx
+++ b/src/app/[locale]/product/_components/ProductOverviewCard.tsx
@@ -251,7 +251,6 @@ export function ProductOverviewCard(props: ProductOverviewCardProps) {
         if (overviewData?.URIOfTheProduct) {
             const url = overviewData.URIOfTheProduct;
             window.open(url, '_blank', 'noopener,noreferrer');
-            navigate.push(url);
         }
     };
 

--- a/src/app/[locale]/product/_components/ProductOverviewCard.tsx
+++ b/src/app/[locale]/product/_components/ProductOverviewCard.tsx
@@ -250,6 +250,7 @@ export function ProductOverviewCard(props: ProductOverviewCardProps) {
     const navigateToProduct = () => {
         if (overviewData?.URIOfTheProduct) {
             const url = overviewData.URIOfTheProduct;
+            window.open(url, '_blank', 'noopener,noreferrer');
             navigate.push(url);
         }
     };


### PR DESCRIPTION
This pull request introduces a small change to the `ProductOverviewCard` component to enhance security and functionality when navigating to a product URL. The change ensures that the product URL is opened in a new tab with secure attributes (`noopener` and `noreferrer`).