### PR TITLE
feat(Footer): add documentation link to footer

### DIFF
--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -15,6 +15,7 @@ export function Footer() {
     const handleAboutDialogClose = () => {
         setAboutDialogOpen(false);
     };
+    const documentationURL = 'https://github.com/eclipse-mnestix/mnestix-browser/wiki';
 
     const t = useTranslations('navigation.footer');
 
@@ -81,6 +82,16 @@ export function Footer() {
                             onClick={() => setAboutDialogOpen(!aboutDialogOpen)}
                         >
                             <Link href="#">{t('about')}</Link>
+                        </Typography>
+
+                        <Typography mx={2} color="text.secondary" fontSize="small">
+                                |
+                        </Typography>
+
+                        <Typography fontSize="small" maxWidth="10rem">
+                                <Link href={documentationURL} target="_blank">
+                                    {t('documentation')}
+                                </Link>
                         </Typography>
                     </Grid>
                 </Grid>

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -174,7 +174,8 @@
     "footer": {
       "about": "Über Mnestix",
       "dataPrivacy": "Datenschutz",
-      "imprint": "Impressum"
+      "imprint": "Impressum",
+      "documentation": "Dokumentation"
     },
     "mainMenu": {
       "aasList": "AAS Liste",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -174,7 +174,8 @@
     "footer": {
       "about": "About Mnestix",
       "dataPrivacy": "Data Privacy",
-      "imprint": "Imprint"
+      "imprint": "Imprint",
+      "documentation": "Documentation"
     },
     "mainMenu": {
       "aasList": "AAS List",

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -174,7 +174,8 @@
     "footer": {
       "about": "Sobre Mnestix",
       "dataPrivacy": "Privacidad",
-      "imprint": "Aviso legal"
+      "imprint": "Aviso legal",
+      "documentation": "Documentación"
     },
     "mainMenu": {
       "aasList": "Lista de AAS",


### PR DESCRIPTION
This pull request adds a "Documentation" link to the footer of the application, along with localization support for the new label. The most important changes include defining the documentation URL, updating the footer layout to include the link, and adding translations for the "Documentation" label in multiple languages.

### Footer Updates:
* [`src/layout/Footer.tsx`](diffhunk://#diff-572eafd1fd6871371a8db00a253950c22004d3c69d83a7fa568e76aee48d9b5eR18): Added a `documentationURL` constant and updated the footer layout to include a "Documentation" link pointing to the specified URL. The link opens in a new tab. [[1]](diffhunk://#diff-572eafd1fd6871371a8db00a253950c22004d3c69d83a7fa568e76aee48d9b5eR18) [[2]](diffhunk://#diff-572eafd1fd6871371a8db00a253950c22004d3c69d83a7fa568e76aee48d9b5eR86-R95)

### Localization Updates:
* [`src/locale/de.json`](diffhunk://#diff-8a55d17950f4eef8fd709822dfad354e3385f72814bd47a751cec3486df747d5L177-R178): Added the German translation for "Documentation" as "Dokumentation."
* [`src/locale/en.json`](diffhunk://#diff-f2b6baf36aa1ae7a209c5dad57f912aa58450beea9696f35d6e08d9cf06d6ec6L177-R178): Added the English translation for "Documentation."
* [`src/locale/es.json`](diffhunk://#diff-3284807b61686fce4a49e58ee6672a78f5a12311bc0b8cdbb36da686ac986b28L177-R178): Added the Spanish translation for "Documentation" as "Documentación."