### PR TITLE
feat(manufacturerCard): Add filterable Aas count

### DIFF
--- a/src/app/[locale]/marketplace/_components/manufacturerCard.tsx
+++ b/src/app/[locale]/marketplace/_components/manufacturerCard.tsx
@@ -18,7 +18,7 @@ export function ManufacturerCard({ connection }: ManufacturerCardProps) {
     const theme = useTheme();
     const t = useTranslations('pages.catalog');
     const navigate = useRouter();
-    const [resultCount, setResultCount] = useState<number | null>(-1);
+    const [resultCount, setResultCount] = useState<number | null>(null);
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
     useAsyncEffect(async () => {
@@ -30,7 +30,6 @@ export function ManufacturerCard({ connection }: ManufacturerCardProps) {
             }
         } catch (error) {
             console.error('Error fetching article count:', error);
-            setResultCount(null);
         } finally {
             setIsLoading(false);
         }
@@ -79,7 +78,7 @@ export function ManufacturerCard({ connection }: ManufacturerCardProps) {
             <Box display="flex" alignItems="center" justifyContent="space-between" mt={2}>
                 {isLoading ? (
                     <CenteredLoadingSpinner />
-                ) : resultCount !== null && resultCount >= 0 ? (
+                ) : resultCount !== null ? (
                     <Typography color="text.secondary" fontSize="1.1rem">
                         {t('articleCount', { count: resultCount ?? 0 })}
                     </Typography>

--- a/src/app/[locale]/marketplace/_components/manufacturerCard.tsx
+++ b/src/app/[locale]/marketplace/_components/manufacturerCard.tsx
@@ -5,6 +5,10 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import { useTranslations } from 'next-intl';
 import { MnestixConnection } from '@prisma/client';
 import { useRouter } from 'next/navigation';
+import { searchProducts } from 'lib/api/graphql/catalogActions';
+import { useAsyncEffect } from 'lib/hooks/UseAsyncEffect';
+import { useState } from 'react';
+import { CenteredLoadingSpinner } from 'components/basics/CenteredLoadingSpinner';
 
 type ManufacturerCardProps = {
     connection: MnestixConnection;
@@ -14,6 +18,23 @@ export function ManufacturerCard({ connection }: ManufacturerCardProps) {
     const theme = useTheme();
     const t = useTranslations('pages.catalog');
     const navigate = useRouter();
+    const [resultCount, setResultCount] = useState<number | null>(-1);
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+
+    useAsyncEffect(async () => {
+        setIsLoading(true);
+        try {
+            if (connection && connection.aasSearcher) {
+                const data = await searchProducts(connection.aasSearcher);
+                setResultCount(Array.isArray(data.result) ? data.result.length : 0);
+            }
+        } catch (error) {
+            console.error('Error fetching article count:', error);
+            setResultCount(null);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
 
     const manufacturer = connection.name || 'unknown';
 
@@ -24,11 +45,6 @@ export function ManufacturerCard({ connection }: ManufacturerCardProps) {
             navigate.push(`/marketplace/catalog?repoUrl=${encodeURIComponent(connection.url)}`);
         }
     };
-
-    const getArticleCount = () => {
-        // Placeholder for article count logic -> needs to be implemented in the AAS Searcher Backend first
-        return  Math.floor(Math.random() * (150 - 10 + 1)) + 10;
-    }
 
     return (
         <Card
@@ -61,9 +77,17 @@ export function ManufacturerCard({ connection }: ManufacturerCardProps) {
                 </Typography>
             )}
             <Box display="flex" alignItems="center" justifyContent="space-between" mt={2}>
-                <Typography color="text.secondary" fontSize="1.1rem">
-                    {t('articleCount', { count: getArticleCount() })}
-                </Typography>
+                {isLoading ? (
+                    <CenteredLoadingSpinner />
+                ) : resultCount !== null && resultCount >= 0 ? (
+                    <Typography color="text.secondary" fontSize="1.1rem">
+                        {t('articleCount', { count: resultCount ?? 0 })}
+                    </Typography>
+                ) : (
+                    <Typography color="text.secondary" fontSize="1.1rem">
+                        {t('articleCountUnavailable')}
+                    </Typography>
+                )}
                 <IconButton
                     onClick={onNavigate}
                     sx={{

--- a/src/app/[locale]/marketplace/catalog/_components/FilterContainer.tsx
+++ b/src/app/[locale]/marketplace/catalog/_components/FilterContainer.tsx
@@ -47,7 +47,7 @@ export function FilterContainer(props: { onFilterChanged(query: FilterQuery[]): 
 
     useAsyncEffect(async () => {
         setLoading(true);
-        const results = await searchProducts(undefined, props.aasSearcherUrl);
+        const results = await searchProducts(props.aasSearcherUrl);
 
         if (results.isSuccess) {
             const products = results.result;
@@ -201,10 +201,7 @@ export function FilterContainer(props: { onFilterChanged(query: FilterQuery[]): 
                             {t('filter')}
                         </Typography>
                         <Box display="flex" gap={1}>
-                            <Button 
-                                variant="contained"
-                                type="button"
-                                onClick={() => applyFilter()}>
+                            <Button variant="contained" type="button" onClick={() => applyFilter()}>
                                 Apply
                             </Button>
                             <Button

--- a/src/app/[locale]/marketplace/catalog/page.tsx
+++ b/src/app/[locale]/marketplace/catalog/page.tsx
@@ -58,7 +58,7 @@ export default function Page() {
                 typeId: '',
                 aasSearcher: null,
                 image: null,
-                commercialData: null
+                commercialData: null,
             };
             setConnection(emptyConnection);
             return emptyConnection;
@@ -76,7 +76,7 @@ export default function Page() {
 
     const loadData = async (aasSearcher?: string, filters?: { key: string; value: string }[]) => {
         setLoading(true);
-        const results = await searchProducts(filters, aasSearcher ?? undefined);
+        const results = await searchProducts(aasSearcher ?? undefined, filters);
 
         if (results.isSuccess) {
             const products = results.result;
@@ -145,10 +145,7 @@ export default function Page() {
                         }}
                         aria-label={t('filter')}
                     >
-                        <FilterContainer
-                            onFilterChanged={onFilterChanged}
-                            aasSearcherUrl={connection?.aasSearcher}
-                        />
+                        <FilterContainer onFilterChanged={onFilterChanged} aasSearcherUrl={connection?.aasSearcher} />
                     </Card>
                 )}
                 <Box flex={1} minWidth={0}>
@@ -164,7 +161,9 @@ export default function Page() {
                         </Card>
                     ) : (
                         <Box>
-                            <Typography variant="body1" color="textSecondary" mb={2}>{t('noSearcherWarning')}</Typography>
+                            <Typography variant="body1" color="textSecondary" mb={2}>
+                                {t('noSearcherWarning')}
+                            </Typography>
                             <AasListDataWrapper repositoryUrl={repositoryUrl} hideRepoSelection={true} />
                         </Box>
                     )}

--- a/src/lib/api/graphql/catalogActions.ts
+++ b/src/lib/api/graphql/catalogActions.ts
@@ -64,7 +64,10 @@ function buildFilterInput(filters?: FilterQuery[]): string {
     return filterArray.length > 1 ? `(where: { or: [${filterArray.join(' , ')}]})` : `(where: { ${filterArray} })`;
 }
 
-export async function searchProducts(filters?: FilterQuery[], aasSearcherUrl?: string, ): Promise<ApiResponseWrapper<SearchResponseEntry[]>> {
+export async function searchProducts(
+    aasSearcherUrl?: string,
+    filters?: FilterQuery[],
+): Promise<ApiResponseWrapper<SearchResponseEntry[]>> {
     if (!aasSearcherUrl) {
         return wrapErrorCode('NOT_FOUND', 'No aasSearcher URL provided');
     }
@@ -82,4 +85,3 @@ export async function searchProducts(filters?: FilterQuery[], aasSearcherUrl?: s
         return wrapErrorCode('UNKNOWN_ERROR', error);
     }
 }
-

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -261,6 +261,7 @@
       "marketplaceTitle": "VWS4LS - Marketplace",
       "marketplaceSubtitle": "Verwaltungsschale für den Leitungssatz",
       "articleCount": "{count, plural, =1 {# Artikel} other {# Artikel}}",
+      "articleCountUnavailable": "Filterung nicht konfiguriert",
       "filter": "Filter",
       "noSearcherWarning": "Kein AAS Searcher konfiguriert. AAS Liste wird angezeigt, Filterung ist nicht möglich.",
       "eclassDocumentationLink": "In ECLASS Dokumentation nachlesen",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -261,6 +261,7 @@
       "marketplaceTitle": "VWS4LS - Marketplace",
       "marketplaceSubtitle": "Asset Administration Shell for Wire Harness",
       "articleCount": "{count, plural, =1 {# article} other {# articles}}",
+      "articleCountUnavailable": "Filtering not configured",
       "filter": "Filter",
       "noSearcherWarning": "No AAS Searcher Configured. Showing AAS List as Fallback, filters won't work.",
       "eclassDocumentationLink": "Open in ECLASS documentation",

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -261,6 +261,7 @@
       "marketplaceTitle": "VWS4LS - Marketplace",
       "marketplaceSubtitle": "Shell de administración de activos para mazos de cables",
       "articleCount": "{count, plural, =1 {# artículo} other {# artículos}}",
+      "articleCountUnavailable": "Filtrado no configurado",
       "filter": "Filtro",
       "noSearcherWarning": "No se ha configurado el buscador AAS - Se muestra la lista AAS",
       "eclassDocumentationLink": "Abrir en la documentación de ECLASS",


### PR DESCRIPTION
# Description

### Improvements to Product Search and Loading States:
* `src/app/[locale]/marketplace/_components/manufacturerCard.tsx`: Replaced the placeholder article count logic with an asynchronous fetch using `searchProducts`. Added loading and error states to display a spinner or fallback text when the product count is unavailable.
* [`src/lib/api/graphql/catalogActions.ts`](diffhunk://#diff-c1ee46582e7df854f1bed244ae6ca520778a5ce9f4d314a78dc6780773200e61L67-R70): Modified the `searchProducts` function to accept `aasSearcherUrl` as the first parameter and `filters` as the second, improving parameter clarity and usage consistency.

### Localization Updates:
* Added a new translation key `articleCountUnavailable` to indicate when filtering is not configured, with updates to `de.json`, `en.json`, and `es.json` to support German, English, and Spanish translations. [[1]](diffhunk://#diff-8a55d17950f4eef8fd709822dfad354e3385f72814bd47a751cec3486df747d5R264) [[2]](diffhunk://#diff-f2b6baf36aa1ae7a209c5dad57f912aa58450beea9696f35d6e08d9cf06d6ec6R264) [[3]](diffhunk://#diff-3284807b61686fce4a49e58ee6672a78f5a12311bc0b8cdbb36da686ac986b28R264)

### Code Simplifications and Consistency:
* `src/app/[locale]/marketplace/catalog/page.tsx`: Adjusted the `searchProducts` calls to align with the updated function signature and reformatted JSX for better readability. 
* `src/app/[locale]/marketplace/catalog/_components/FilterContainer.tsx`: Simplified button formatting and updated the `searchProducts` call to match the new parameter order. 

## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
