### PR TITLE
fix(filter-select): verify if correct family root is selected

### DIFF
--- a/src/app/[locale]/marketplace/catalog/_components/FilterContainer.tsx
+++ b/src/app/[locale]/marketplace/catalog/_components/FilterContainer.tsx
@@ -181,7 +181,6 @@ export function FilterContainer(props: { onFilterChanged(query: FilterQuery[]): 
     }
 
     function applyFilter(reset = false) {
-        console.log(activeFilters);
         if (reset) {
             setActiveFilters([]);
             props.onFilterChanged([]);
@@ -201,10 +200,7 @@ export function FilterContainer(props: { onFilterChanged(query: FilterQuery[]): 
                             {t('filter')}
                         </Typography>
                         <Box display="flex" gap={1}>
-                            <Button 
-                                variant="contained"
-                                type="button"
-                                onClick={() => applyFilter()}>
+                            <Button variant="contained" type="button" onClick={() => applyFilter()}>
                                 Apply
                             </Button>
                             <Button

--- a/src/app/[locale]/marketplace/catalog/_components/ProductCategoryFilter.tsx
+++ b/src/app/[locale]/marketplace/catalog/_components/ProductCategoryFilter.tsx
@@ -136,7 +136,6 @@ export function ProductCategoryFilter(props: {
                     ProductFamilies: updatedFamilies,
                 },
             };
-            console.log(categories);
 
             return categories;
         });

--- a/src/app/[locale]/marketplace/catalog/_components/ProductCategoryFilter.tsx
+++ b/src/app/[locale]/marketplace/catalog/_components/ProductCategoryFilter.tsx
@@ -75,8 +75,17 @@ export function ProductCategoryFilter(props: {
         prevFilters: ProductCategory[],
         node: ProductRoot | ProductFamily | ProductDesignation,
         isChecked: boolean,
+        rootName?: string,
     ) {
         return prevFilters.map((category) => {
+            // By default, all categories retain their previous state.
+            // If a family or designation name matches in the root name,
+            // it is marked as checked accordingly.
+            // Therefore, we verify if the selected family or designation name matches the root name being checked.
+            if (rootName !== undefined && category.ProductRoot.name !== rootName) {
+                return category;
+            }
+
             const isRootNode = category.ProductRoot.name === node.name;
             const updatedRoot = { ...category.ProductRoot };
 
@@ -133,9 +142,13 @@ export function ProductCategoryFilter(props: {
         });
     }
 
-    function updateCheckboxState(node: ProductRoot | ProductFamily | ProductDesignation, isChecked: boolean) {
+    function updateCheckboxState(
+        node: ProductRoot | ProductFamily | ProductDesignation,
+        isChecked: boolean,
+        rootName?: string,
+    ) {
         setFilters((prevFilters) => {
-            const updatedFilters = updateActiveFilters(prevFilters, node, isChecked);
+            const updatedFilters = updateActiveFilters(prevFilters, node, isChecked, rootName);
             return updatedFilters;
         });
     }
@@ -191,7 +204,11 @@ export function ProductCategoryFilter(props: {
                                                         onClick={(event) => event.stopPropagation()}
                                                         checked={productFamily.value}
                                                         onChange={(event) =>
-                                                            updateCheckboxState(productFamily, event.target.checked)
+                                                            updateCheckboxState(
+                                                                productFamily,
+                                                                event.target.checked,
+                                                                productCategory.ProductRoot.name,
+                                                            )
                                                         }
                                                         sx={{ padding: '4px' }}
                                                     />
@@ -214,6 +231,7 @@ export function ProductCategoryFilter(props: {
                                                             updateCheckboxState(
                                                                 productDesignation,
                                                                 event.target.checked,
+                                                                productCategory.ProductRoot.name,
                                                             )
                                                         }
                                                         sx={{ padding: '6px' }}

--- a/src/lib/api/graphql/catalogActions.ts
+++ b/src/lib/api/graphql/catalogActions.ts
@@ -64,12 +64,14 @@ function buildFilterInput(filters?: FilterQuery[]): string {
     return filterArray.length > 1 ? `(where: { or: [${filterArray.join(' , ')}]})` : `(where: { ${filterArray} })`;
 }
 
-export async function searchProducts(filters?: FilterQuery[], aasSearcherUrl?: string, ): Promise<ApiResponseWrapper<SearchResponseEntry[]>> {
+export async function searchProducts(
+    filters?: FilterQuery[],
+    aasSearcherUrl?: string,
+): Promise<ApiResponseWrapper<SearchResponseEntry[]>> {
     if (!aasSearcherUrl) {
         return wrapErrorCode('NOT_FOUND', 'No aasSearcher URL provided');
     }
     const queryString = searchQuery(buildFilterInput(filters));
-    console.log(queryString);
     const query = gql(queryString);
     try {
         const client = createApolloClient(aasSearcherUrl);
@@ -82,4 +84,3 @@ export async function searchProducts(filters?: FilterQuery[], aasSearcherUrl?: s
         return wrapErrorCode('UNKNOWN_ERROR', error);
     }
 }
-


### PR DESCRIPTION
# Description

This pull request updates the `ProductCategoryFilter` component to enhance the filtering logic by introducing a `rootName` parameter. This parameter ensures that checkbox state updates are scoped to the relevant product root, improving the accuracy of filter interactions.

### Enhancements to filtering logic:

* `updateActiveFilters` function: Added an optional `rootName` parameter to refine the filtering logic. The function now verifies if the selected family or designation matches the specified root name before updating the filter state. 
* `updateCheckboxState` function: Updated to accept the `rootName` parameter and pass it to the `updateActiveFilters` function, ensuring that filter updates are scoped to the correct product root. 
### Integration of `rootName` in event handlers:

* Checkbox event handler for `productFamily`: Modified to pass the `productCategory.ProductRoot.name` as the `rootName` parameter, ensuring that the state update is tied to the correct product root. 
* Checkbox event handler for `productDesignation`: Similarly updated to include the `productCategory.ProductRoot.name` as the `rootName` parameter for accurate state updates. 

## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
