### PR TITLE
style(rbac): adjustments for rule naming and creation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @GailMelanie @hofermo @JonathanXITASO @pawel-baran-se @XAlinaGS @NilsXitaso @milofranke @Copilot
+* @GailMelanie @hofermo @JonathanXITASO @pawel-baran-se @XAlinaGS @NilsXitaso @milofranke

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @GailMelanie @hofermo @JonathanXITASO @pawel-baran-se @XAlinaGS @NilsXitaso @milofranke @sirchnik-xitaso
+* @GailMelanie @hofermo @JonathanXITASO @pawel-baran-se @XAlinaGS @NilsXitaso @milofranke @Copilot

--- a/docker-compose/compose.proxy.yml
+++ b/docker-compose/compose.proxy.yml
@@ -1,9 +1,9 @@
 services:
-  mnestix-proxy:
-    image: mnestix/mnestix-proxy:dev
+  mnestix-proxy:mnestix-proxy:
+    image: mnestix-proxy:0.0.1
     container_name: mnestix-proxy
     ports:
-      - '5065:5065'
+      - 5065:5065
     environment:
       # API key authorization
       CustomerEndpointsSecurity__ApiKey: ${MNESTIX_BACKEND_API_KEY:-verySecureApiKey}

--- a/docker-compose/compose.proxy.yml
+++ b/docker-compose/compose.proxy.yml
@@ -1,5 +1,5 @@
 services:
-  mnestix-proxy:mnestix-proxy:
+  mnestix-proxy:
     image: mnestix-proxy:0.0.1
     container_name: mnestix-proxy
     ports:

--- a/docker-compose/compose.proxy.yml
+++ b/docker-compose/compose.proxy.yml
@@ -1,9 +1,9 @@
 services:
   mnestix-proxy:
-    image: mnestix-proxy:0.0.1
+    image: mnestix/mnestix-proxy:dev
     container_name: mnestix-proxy
     ports:
-      - 5065:5065
+      - '5065:5065'
     environment:
       # API key authorization
       CustomerEndpointsSecurity__ApiKey: ${MNESTIX_BACKEND_API_KEY:-verySecureApiKey}

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "docker:keycloak": "docker compose -f compose.yml -f docker-compose/compose.keycloak.yml up",
     "docker:azure": "docker compose -f compose.yml -f docker-compose/compose.azure_ad.yml up",
     "docker:rbac": "docker compose -f compose.yml -f docker-compose/compose.dynamic-rbac.yml up",
-    "docker:proxy": "docker compose -f compose.yml -f docker-compose/compose.proxy.yml -f docker-compose/compose.dynamic-rbac.yml up"
+    "docker:proxy": "docker compose -f compose.yml -f docker-compose/compose.proxy.yml up"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "docker:prune": "docker compose -f compose.yml  -f docker-compose/compose.test.yml -f docker-compose/compose.keycloak.yml down -v && docker network prune && docker network rm mnestix-network",
     "docker:keycloak": "docker compose -f compose.yml -f docker-compose/compose.keycloak.yml up",
     "docker:azure": "docker compose -f compose.yml -f docker-compose/compose.azure_ad.yml up",
-    "docker:rbac": "docker compose -f compose.yml -f docker-compose/compose.dynamic-rbac.yml up"
+    "docker:rbac": "docker compose -f compose.yml -f docker-compose/compose.dynamic-rbac.yml up",
+    "docker:proxy": "docker compose -f compose.yml -f docker-compose/compose.proxy.yml -f docker-compose/compose.dynamic-rbac.yml up"
   },
   "browserslist": {
     "production": [

--- a/src/app/[locale]/marketplace/catalog/_components/FilterContainer.tsx
+++ b/src/app/[locale]/marketplace/catalog/_components/FilterContainer.tsx
@@ -159,7 +159,6 @@ export function FilterContainer(props: { onFilterChanged(query: FilterQuery[]): 
         });    }
 
     function applyFilter() {
-        console.log(activeFilters);
         props.onFilterChanged(activeFilters);
     }
 

--- a/src/app/[locale]/marketplace/catalog/_components/ProductCategoryFilter.tsx
+++ b/src/app/[locale]/marketplace/catalog/_components/ProductCategoryFilter.tsx
@@ -90,33 +90,27 @@ export function ProductCategoryFilter(props: {
                     value: designation.name === node.name ? isChecked : designation.value,
                 }));
 
-                const updatedFamily = {
+                return {
                     ...family,
                     value: updatedDesignations.every((d) => d.value),
                     ProductDesignations: updatedDesignations,
                 };
-
-                return updatedFamily;
             });
 
             updatedRoot.value = updatedFamilies.every((family) => family.value);
 
-            const categories = {
+            return {
                 ProductRoot: {
                     ...updatedRoot,
                     ProductFamilies: updatedFamilies,
                 },
             };
-            console.log(categories);
-
-            return categories;
         });
     }
 
     function updateCheckboxState(node: ProductRoot | ProductFamily | ProductDesignation, isChecked: boolean) {
         setFilters((prevFilters) => {
-            const updatedFilters = updateActiveFilters(prevFilters, node, isChecked);
-            return updatedFilters;
+            return updateActiveFilters(prevFilters, node, isChecked);
         });
     }
 

--- a/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.spec.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.spec.tsx
@@ -6,6 +6,7 @@ import { useNotificationSpawner } from 'lib/hooks/UseNotificationSpawner';
 import { act } from 'react';
 import { ApiResultStatus } from 'lib/util/apiResponseWrapper/apiResultStatus';
 import { EnvProvider } from 'app/EnvProvider';
+import { RoleOptions } from './RuleSettings';
 
 jest.mock('./../../../../../lib/services/rbac-service/RbacActions');
 jest.mock('next-intl', () => ({
@@ -20,7 +21,7 @@ jest.mock('./../../../../../lib/services/envAction', () => ({
     }),
 }));
 
-async function renderCreateRuleDialog(availableRoles?: string[]) {
+async function renderCreateRuleDialog(availableRoles?: RoleOptions[]) {
     const onClose = jest.fn();
     const reloadRules = jest.fn().mockResolvedValue(undefined);
 
@@ -30,7 +31,7 @@ async function renderCreateRuleDialog(availableRoles?: string[]) {
                 open={true}
                 onClose={onClose}
                 reloadRules={reloadRules}
-                availableRoles={availableRoles ?? ['Role1', 'Role2']}
+                availableRoles={availableRoles ?? [{ name: 'Role1' }, { name: 'Role2' }]}
             />,
             {
                 wrapper: ({ children }) => <EnvProvider>{children}</EnvProvider>,

--- a/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.spec.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.spec.tsx
@@ -23,6 +23,7 @@ jest.mock('./../../../../../lib/services/envAction', () => ({
 
 async function renderCreateRuleDialog(availableRoles?: RoleOptions[]) {
     const onClose = jest.fn();
+    const afterClose = jest.fn();
     const reloadRules = jest.fn().mockResolvedValue(undefined);
 
     await act(async () => {
@@ -30,6 +31,7 @@ async function renderCreateRuleDialog(availableRoles?: RoleOptions[]) {
             <CreateRuleDialog
                 open={true}
                 onClose={onClose}
+                afterClose={afterClose}
                 reloadRules={reloadRules}
                 availableRoles={availableRoles ?? [{ name: 'Role1' }, { name: 'Role2' }]}
             />,
@@ -39,7 +41,7 @@ async function renderCreateRuleDialog(availableRoles?: RoleOptions[]) {
         );
     });
 
-    return { onClose, reloadRules };
+    return { onClose, afterClose, reloadRules };
 }
 
 function doMock(createRbacError?: string) {

--- a/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.tsx
@@ -25,7 +25,7 @@ export const defaultRbacRule: BaSyxRbacRule = {
     idShort: '',
 };
 
-export const CreateRuleDialog = ({ onClose, reloadRules, open, availableRoles, selectedRole }: RoleDialogProps) => {
+export function CreateRuleDialog({ onClose, reloadRules, open, availableRoles, selectedRole }: RoleDialogProps) {
     const t = useTranslations('pages.settings.rules');
     const { showError } = useShowError();
     const notificationSpawner = useNotificationSpawner();
@@ -94,4 +94,4 @@ export const CreateRuleDialog = ({ onClose, reloadRules, open, availableRoles, s
             </Box>
         </Dialog>
     );
-};
+}

--- a/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.tsx
@@ -15,6 +15,7 @@ type RoleDialogProps = {
     readonly reloadRules: () => Promise<void>;
     readonly open: boolean;
     readonly availableRoles: string[];
+    readonly selectedRole?: string | null;
 };
 
 export const defaultRbacRule: BaSyxRbacRule = {
@@ -24,7 +25,7 @@ export const defaultRbacRule: BaSyxRbacRule = {
     idShort: '',
 };
 
-export const CreateRuleDialog = ({ onClose, reloadRules, open, availableRoles }: RoleDialogProps) => {
+export const CreateRuleDialog = ({ onClose, reloadRules, open, availableRoles, selectedRole }: RoleDialogProps) => {
     const t = useTranslations('pages.settings.rules');
     const { showError } = useShowError();
     const notificationSpawner = useNotificationSpawner();
@@ -87,6 +88,7 @@ export const CreateRuleDialog = ({ onClose, reloadRules, open, availableRoles }:
                         onSubmit={onSubmit}
                         onCancel={onClose}
                         availableRoles={availableRoles}
+                        selectedRole={selectedRole}
                     />
                 )}
             </Box>

--- a/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.tsx
@@ -13,6 +13,7 @@ import { RoleOptions } from './RuleSettings';
 
 type RoleDialogProps = {
     readonly onClose: () => void;
+    readonly afterClose: () => void;
     readonly reloadRules: () => Promise<void>;
     readonly open: boolean;
     readonly availableRoles: RoleOptions[];
@@ -26,7 +27,7 @@ export const defaultRbacRule: BaSyxRbacRule = {
     idShort: '',
 };
 
-export function CreateRuleDialog({ onClose, reloadRules, open, availableRoles, selectedRole }: RoleDialogProps) {
+export function CreateRuleDialog({ onClose, afterClose, reloadRules, open, availableRoles, selectedRole }: RoleDialogProps) {
     const t = useTranslations('pages.settings.rules');
     const { showError } = useShowError();
     const notificationSpawner = useNotificationSpawner();
@@ -66,6 +67,11 @@ export function CreateRuleDialog({ onClose, reloadRules, open, availableRoles, s
 
         showError(response);
     }
+    
+    function resetState() {
+        setShowHint(false);
+        afterClose();
+    }
 
     return (
         <Dialog
@@ -73,10 +79,7 @@ export function CreateRuleDialog({ onClose, reloadRules, open, availableRoles, s
             onClose={onClose}
             maxWidth="md"
             fullWidth={true}
-            onTransitionExited={() => {
-                // This function is called when the dialog close transition ends
-                setShowHint(false);
-            }}
+            onTransitionExited={resetState}
         >
             <Box sx={{ mx: '2rem', mt: '1.5rem', mb: '1rem' }} data-testid="role-create-dialog">
                 <DialogCloseButton handleClose={onClose} dataTestId="rule-create-close-button" />

--- a/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/CreateRuleDialog.tsx
@@ -9,12 +9,13 @@ import { useNotificationSpawner } from 'lib/hooks/UseNotificationSpawner';
 import { RuleForm, RuleFormModel } from 'app/[locale]/settings/_components/role-settings/RuleForm';
 import { useState } from 'react';
 import { KeycloakHint } from 'app/[locale]/settings/_components/role-settings/HintDialogContent';
+import { RoleOptions } from './RuleSettings';
 
 type RoleDialogProps = {
     readonly onClose: () => void;
     readonly reloadRules: () => Promise<void>;
     readonly open: boolean;
-    readonly availableRoles: string[];
+    readonly availableRoles: RoleOptions[];
     readonly selectedRole?: string | null;
 };
 
@@ -33,7 +34,7 @@ export function CreateRuleDialog({ onClose, reloadRules, open, availableRoles, s
     const [showHint, setShowHint] = useState(false);
 
     async function afterSubmit(newData: RuleFormModel) {
-        const isNewRole = !availableRoles.includes(newData.role);
+        const isNewRole = !availableRoles.some((role) => role.name === newData.role.name);
         if (isNewRole) {
             setShowHint(true);
         } else {

--- a/src/app/[locale]/settings/_components/role-settings/DeleteRoleDialog.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/DeleteRoleDialog.tsx
@@ -12,6 +12,7 @@ import { deleteRbacRule } from 'lib/services/rbac-service/RbacActions';
 
 type RuleDialogProps = {
     readonly onClose: () => void;
+    readonly afterClose: () => void;
     readonly reloadRules: () => Promise<void>;
     readonly open: boolean;
     readonly roleName: string;
@@ -20,7 +21,7 @@ type RuleDialogProps = {
 
 type DialogMode = 'delete-role' | 'delete-hint';
 
-export const DeleteRoleDialog = ({ onClose, reloadRules, open, roleName, rules }: RuleDialogProps) => {
+export const DeleteRoleDialog = ({ onClose, afterClose, reloadRules, open, roleName, rules }: RuleDialogProps) => {
     const t = useTranslations('pages.settings.rules');
     const [dialogMode, setDialogMode] = useState<DialogMode>('delete-role');
     const [isDeleting, setIsDeleting] = useState(false);
@@ -56,7 +57,7 @@ export const DeleteRoleDialog = ({ onClose, reloadRules, open, roleName, rules }
         const deleteSuccess = await deleteAllRules();
         if (deleteSuccess) {
             onClose();
-            await new Promise( resolve => setTimeout(resolve, 1000) ); // Wait for the notification to be shown
+            await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for the notification to be shown
             setDialogMode('delete-hint');
         } else {
             onClose();
@@ -117,17 +118,13 @@ export const DeleteRoleDialog = ({ onClose, reloadRules, open, roleName, rules }
         if (open) setDialogMode('delete-role');
     }, [open]);
 
+    function resetState() {
+        setDialogMode('delete-role');
+        afterClose();
+    }
+
     return (
-        <Dialog
-            open={open}
-            onClose={onClose}
-            maxWidth="md"
-            fullWidth={true}
-            onTransitionExited={() => {
-                // This function is called when the dialog close transition ends
-                if (!open) setDialogMode('delete-role');
-            }}
-        >
+        <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth={true} onTransitionExited={() => resetState()}>
             <Box sx={{ mx: '2rem', mt: '1.5rem', mb: '1rem' }} data-testid="role-dialog">
                 <DialogCloseButton handleClose={onClose} dataTestId="dialog-close-button" />
                 <DialogViewContent />

--- a/src/app/[locale]/settings/_components/role-settings/DeleteRoleDialog.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/DeleteRoleDialog.tsx
@@ -55,11 +55,13 @@ export const DeleteRoleDialog = ({ onClose, reloadRules, open, roleName, rules }
     async function onDelete() {
         const deleteSuccess = await deleteAllRules();
         if (deleteSuccess) {
+            onClose();
+            await new Promise( resolve => setTimeout(resolve, 1000) ); // Wait for the notification to be shown
             setDialogMode('delete-hint');
         } else {
             onClose();
-            await reloadRules();
         }
+        await reloadRules();
     }
 
     function RoleDeleteContent() {
@@ -67,10 +69,10 @@ export const DeleteRoleDialog = ({ onClose, reloadRules, open, roleName, rules }
             <>
                 <DialogContent data-testid="role-settings-delete-role-dialog">
                     <Box display="flex" flexDirection="column">
-                        <Typography color="text.secondary" variant="body2">
+                        <Typography variant="h2" color="primary" sx={{ mb: '1rem' }}>
                             {t('deleteRole.header')}
                         </Typography>
-                        <Typography color="primary" variant="body2">
+                        <Typography variant="body1" color="text.secondary" sx={{ mb: '0.5rem' }}>
                             {t('deleteRole.description', { roleName: roleName, count: rules.length })}
                         </Typography>
                     </Box>
@@ -123,7 +125,7 @@ export const DeleteRoleDialog = ({ onClose, reloadRules, open, roleName, rules }
             fullWidth={true}
             onTransitionExited={() => {
                 // This function is called when the dialog close transition ends
-                setDialogMode('delete-role');
+                if (!open) setDialogMode('delete-role');
             }}
         >
             <Box sx={{ mx: '2rem', mt: '1.5rem', mb: '1rem' }} data-testid="role-dialog">

--- a/src/app/[locale]/settings/_components/role-settings/DeleteRoleDialog.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/DeleteRoleDialog.tsx
@@ -1,0 +1,135 @@
+import { Box, Button, Dialog, DialogActions, DialogContent, Typography } from '@mui/material';
+import { useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
+import { Delete } from '@mui/icons-material';
+import { DialogCloseButton } from 'components/basics/DialogCloseButton';
+import { useShowError } from 'lib/hooks/UseShowError';
+import { useNotificationSpawner } from 'lib/hooks/UseNotificationSpawner';
+import { BaSyxRbacRule } from 'lib/services/rbac-service/types/RbacServiceData';
+import { KeycloakHint } from 'app/[locale]/settings/_components/role-settings/HintDialogContent';
+import CancelIcon from '@mui/icons-material/Cancel';
+import { deleteRbacRule } from 'lib/services/rbac-service/RbacActions';
+
+type RuleDialogProps = {
+    readonly onClose: () => void;
+    readonly reloadRules: () => Promise<void>;
+    readonly open: boolean;
+    readonly roleName: string;
+    readonly rules: BaSyxRbacRule[];
+};
+
+type DialogMode = 'delete-role' | 'delete-hint';
+
+export const DeleteRoleDialog = ({ onClose, reloadRules, open, roleName, rules }: RuleDialogProps) => {
+    const t = useTranslations('pages.settings.rules');
+    const [dialogMode, setDialogMode] = useState<DialogMode>('delete-role');
+    const [isDeleting, setIsDeleting] = useState(false);
+    const { showError } = useShowError();
+    const notificationSpawner = useNotificationSpawner();
+
+    async function deleteAllRules() {
+        try {
+            setIsDeleting(true);
+            const result = await Promise.all(rules.map(async (rule) => deleteRbacRule(rule.idShort)));
+            const failedDeletes = result.filter((response) => !response.isSuccess);
+            if (failedDeletes.length > 0) {
+                notificationSpawner.spawn({
+                    message: t('deleteRole.partiallySuccess', { count: failedDeletes.length, total: rules.length }),
+                    severity: 'warning',
+                });
+                return false;
+            }
+            notificationSpawner.spawn({
+                message: t('deleteRole.success'),
+                severity: 'success',
+            });
+        } catch (error) {
+            showError(error);
+            return false;
+        } finally {
+            setIsDeleting(false);
+        }
+        return true;
+    }
+
+    async function onDelete() {
+        const deleteSuccess = await deleteAllRules();
+        if (deleteSuccess) {
+            setDialogMode('delete-hint');
+        } else {
+            onClose();
+            await reloadRules();
+        }
+    }
+
+    function RoleDeleteContent() {
+        return (
+            <>
+                <DialogContent data-testid="role-settings-delete-role-dialog">
+                    <Box display="flex" flexDirection="column">
+                        <Typography color="text.secondary" variant="body2">
+                            {t('deleteRole.header')}
+                        </Typography>
+                        <Typography color="primary" variant="body2">
+                            {t('deleteRole.description', { roleName: roleName, count: rules.length })}
+                        </Typography>
+                    </Box>
+                </DialogContent>
+                <DialogActions>
+                    <Button
+                        sx={{ mr: 2 }}
+                        startIcon={<CancelIcon />}
+                        variant="outlined"
+                        data-testid="role-settings-delete-role-cancel-button"
+                        onClick={onClose}
+                        disabled={isDeleting}
+                    >
+                        {t('buttons.cancel')}
+                    </Button>
+                    <Button
+                        variant="outlined"
+                        startIcon={<Delete />}
+                        color="error"
+                        data-testid="role-settings-delete-role-delete-button"
+                        onClick={onDelete}
+                        disabled={isDeleting}
+                    >
+                        {t('buttons.delete')}
+                    </Button>
+                </DialogActions>
+            </>
+        );
+    }
+
+    function DialogViewContent() {
+        switch (dialogMode) {
+            case 'delete-role':
+                return <RoleDeleteContent />;
+            case 'delete-hint':
+                return <KeycloakHint hint="delete" onClose={onClose} />;
+        }
+    }
+
+    useEffect(() => {
+        // Reset dialog mode when the dialog opens
+        if (open) setDialogMode('delete-role');
+    }, [open]);
+
+    return (
+        <Dialog
+            open={open}
+            onClose={onClose}
+            maxWidth="md"
+            fullWidth={true}
+            onTransitionExited={() => {
+                // This function is called when the dialog close transition ends
+                setDialogMode('delete-role');
+            }}
+        >
+            <Box sx={{ mx: '2rem', mt: '1.5rem', mb: '1rem' }} data-testid="role-dialog">
+                <DialogCloseButton handleClose={onClose} dataTestId="dialog-close-button" />
+                <DialogViewContent />
+            </Box>
+        </Dialog>
+    );
+};

--- a/src/app/[locale]/settings/_components/role-settings/DeleteRoleDialog.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/DeleteRoleDialog.tsx
@@ -40,7 +40,7 @@ export const DeleteRoleDialog = ({ onClose, reloadRules, open, roleName, rules }
                 return false;
             }
             notificationSpawner.spawn({
-                message: t('deleteRole.success'),
+                message: t('deleteRole.success', { roleName: roleName }),
                 severity: 'success',
             });
         } catch (error) {

--- a/src/app/[locale]/settings/_components/role-settings/DeleteRuleDialogContent.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/DeleteRuleDialogContent.tsx
@@ -14,7 +14,7 @@ interface RuleDeleteDialogProps {
     rule: BaSyxRbacRule;
 }
 
-export function RuleDeleteDialog({ onCancelDialog, onDelete, rule }: RuleDeleteDialogProps) {
+export function DeleteRuleDialogContent({ onCancelDialog, onDelete, rule }: RuleDeleteDialogProps) {
     const t = useTranslations('pages.settings.rules');
     const { showError } = useShowError();
     const notificationSpawner = useNotificationSpawner();

--- a/src/app/[locale]/settings/_components/role-settings/FormMappingHelper.spec.ts
+++ b/src/app/[locale]/settings/_components/role-settings/FormMappingHelper.spec.ts
@@ -17,7 +17,7 @@ describe('FormMappingHelper', () => {
             };
 
             const expectedFormModel: RuleFormModel = {
-                role: 'admin',
+                role: { name: 'admin' },
                 type: 'aas-environment',
                 action: 'READ',
                 targetInformation: {
@@ -38,7 +38,7 @@ describe('FormMappingHelper', () => {
     describe('mapFormModelToBaSyxRbacRule', () => {
         it('should map RoleFormModel to BaSyxRbacRule correctly', () => {
             const formModel: RuleFormModel = {
-                role: 'admin-new',
+                role: { name: 'admin-new' },
                 type: 'aas-environment',
                 action: 'READ',
                 targetInformation: {

--- a/src/app/[locale]/settings/_components/role-settings/FormMappingHelper.ts
+++ b/src/app/[locale]/settings/_components/role-settings/FormMappingHelper.ts
@@ -115,7 +115,7 @@ const mapTargetInformationFormModelToDto = (
 
 export const mapBaSyxRbacRuleToFormModel = (role: BaSyxRbacRule): RuleFormModel => {
     return {
-        role: role.role,
+        role: { name: role.role },
         type: role.targetInformation['@type'],
         action: role.action,
         targetInformation: mapDtoToTargetInformationFormModel(role.targetInformation),
@@ -126,7 +126,7 @@ export const mapFormModelToBaSyxRbacRule = (formModel: RuleFormModel, role: BaSy
     const targetInformation = mapTargetInformationFormModelToDto(formModel.targetInformation, formModel.type);
     return {
         idShort: role.idShort,
-        role: formModel.role,
+        role: typeof formModel.role === 'string' ? formModel.role : formModel.role.name,
         action: formModel.action,
         targetInformation: targetInformation,
     };

--- a/src/app/[locale]/settings/_components/role-settings/RoleAccordion.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RoleAccordion.tsx
@@ -145,7 +145,11 @@ export function RoleAccordion({
                 )}
                 <TableCell sx={{ width: '2rem', textAlign: 'center' }} data-testid="rulesettings-header-empty">
                     <Box>
-                        <Button variant="contained" onClick={() => openCreateDialog(roleName)}>
+                        <Button
+                            variant="contained"
+                            onClick={() => openCreateDialog(roleName)}
+                            aria-label={t('buttons.create')}
+                        >
                             <AddIcon />
                         </Button>
                     </Box>

--- a/src/app/[locale]/settings/_components/role-settings/RoleAccordion.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RoleAccordion.tsx
@@ -3,6 +3,7 @@ import {
     AccordionDetails,
     AccordionSummary,
     Box,
+    Button,
     Chip,
     Table,
     TableBody,
@@ -18,6 +19,7 @@ import { useIsMobile } from 'lib/hooks/UseBreakpoints';
 import { RoundedIconButton } from 'components/basics/Buttons';
 import { BaSyxRbacRule } from 'lib/services/rbac-service/types/RbacServiceData';
 import { useTranslations } from 'next-intl';
+import AddIcon from '@mui/icons-material/Add';
 
 const PERMISSION_CATEGORY_PRIORITY_ORDER = [
     'aasIds',
@@ -31,10 +33,12 @@ export function RoleAccordion({
     roleName,
     rules,
     openDetailDialog,
+    openCreateDialog,
 }: {
     roleName: string;
     rules: BaSyxRbacRule[];
     openDetailDialog: (entry: BaSyxRbacRule) => void;
+    openCreateDialog: (roleName: string | null) => void;
 }) {
     const [isExpanded, setExpanded] = useState(false);
     const isMobile = useIsMobile();
@@ -139,7 +143,13 @@ export function RoleAccordion({
                         {t('tableHeader.permissions')}
                     </TableCell>
                 )}
-                <TableCell sx={tableHeaderText} data-testid="rulesettings-header-empty"></TableCell>
+                <TableCell sx={{ width: '2rem', textAlign: 'center' }} data-testid="rulesettings-header-empty">
+                    <Box>
+                        <Button variant="contained" onClick={() => openCreateDialog(roleName)}>
+                            <AddIcon />
+                        </Button>
+                    </Box>
+                </TableCell>
             </TableRow>
         );
     }
@@ -169,7 +179,7 @@ export function RoleAccordion({
                                 <PermissionCell entry={entry} />
                             </TableCell>
                         )}
-                        <TableCell sx={{ borderBottom: '0px', borderTop: '1px solid #eee' }}>
+                        <TableCell sx={{ borderBottom: '0px', borderTop: '1px solid #eee', textAlign: 'center' }}>
                             <RoundedIconButton
                                 data-testid={`role-settings-button-${entry.idShort}`}
                                 onClick={() => openDetailDialog(entry)}

--- a/src/app/[locale]/settings/_components/role-settings/RoleAccordion.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RoleAccordion.tsx
@@ -38,7 +38,7 @@ export function RoleAccordion({
     roleName: string;
     rules: BaSyxRbacRule[];
     openDetailDialog: (entry: BaSyxRbacRule) => void;
-    openCreateDialog: (roleName: string | null) => void;
+    openCreateDialog: (roleName: string) => void;
     openDeleteRoleDialog: (roleName: string) => void;
 }) {
     const [isExpanded, setExpanded] = useState(false);

--- a/src/app/[locale]/settings/_components/role-settings/RoleAccordion.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RoleAccordion.tsx
@@ -3,7 +3,6 @@ import {
     AccordionDetails,
     AccordionSummary,
     Box,
-    Button,
     Chip,
     Table,
     TableBody,
@@ -19,7 +18,7 @@ import { useIsMobile } from 'lib/hooks/UseBreakpoints';
 import { RoundedIconButton } from 'components/basics/Buttons';
 import { BaSyxRbacRule } from 'lib/services/rbac-service/types/RbacServiceData';
 import { useTranslations } from 'next-intl';
-import AddIcon from '@mui/icons-material/Add';
+import { RoleActionMenu } from './RoleActionMenu';
 
 const PERMISSION_CATEGORY_PRIORITY_ORDER = [
     'aasIds',
@@ -34,11 +33,13 @@ export function RoleAccordion({
     rules,
     openDetailDialog,
     openCreateDialog,
+    openDeleteRoleDialog,
 }: {
     roleName: string;
     rules: BaSyxRbacRule[];
     openDetailDialog: (entry: BaSyxRbacRule) => void;
     openCreateDialog: (roleName: string | null) => void;
+    openDeleteRoleDialog: (roleName: string) => void;
 }) {
     const [isExpanded, setExpanded] = useState(false);
     const isMobile = useIsMobile();
@@ -145,13 +146,11 @@ export function RoleAccordion({
                 )}
                 <TableCell sx={{ width: '2rem', textAlign: 'center' }} data-testid="rulesettings-header-empty">
                     <Box>
-                        <Button
-                            variant="contained"
-                            onClick={() => openCreateDialog(roleName)}
-                            aria-label={t('buttons.create')}
-                        >
-                            <AddIcon />
-                        </Button>
+                        <RoleActionMenu
+                            roleName={roleName}
+                            openCreateDialog={openCreateDialog}
+                            openDeleteRoleDialog={openDeleteRoleDialog}
+                        />
                     </Box>
                 </TableCell>
             </TableRow>

--- a/src/app/[locale]/settings/_components/role-settings/RoleActionMenu.spec.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RoleActionMenu.spec.tsx
@@ -1,0 +1,106 @@
+import { screen, fireEvent } from '@testing-library/react';
+import { expect } from '@jest/globals';
+import { RoleActionMenu } from './RoleActionMenu';
+import { CustomRender } from 'test-utils/CustomRender';
+
+describe('RoleActionMenu', () => {
+    const mockOpenCreateDialog = jest.fn();
+    const mockOpenDeleteRoleDialog = jest.fn();
+    const testRoleName = 'test-role';
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders the menu button', () => {
+        CustomRender(
+            <RoleActionMenu
+                roleName={testRoleName}
+                openCreateDialog={mockOpenCreateDialog}
+                openDeleteRoleDialog={mockOpenDeleteRoleDialog}
+            />,
+        );
+
+        const menuButton = screen.getByRole('button');
+        expect(menuButton).toBeInTheDocument();
+    });
+
+    it('opens menu when button is clicked', () => {
+        CustomRender(
+            <RoleActionMenu
+                roleName={testRoleName}
+                openCreateDialog={mockOpenCreateDialog}
+                openDeleteRoleDialog={mockOpenDeleteRoleDialog}
+            />,
+        );
+
+        const menuButton = screen.getByRole('button');
+        fireEvent.click(menuButton);
+
+        // Check if menu items are visible
+        expect(screen.getByTestId('create-rule-menu-item')).toBeInTheDocument();
+        expect(screen.getByTestId('delete-role-menu-item')).toBeInTheDocument();
+    });
+
+    it('calls openCreateDialog with roleName when create rule is clicked', () => {
+        CustomRender(
+            <RoleActionMenu
+                roleName={testRoleName}
+                openCreateDialog={mockOpenCreateDialog}
+                openDeleteRoleDialog={mockOpenDeleteRoleDialog}
+            />,
+        );
+
+        // Open menu
+        const menuButton = screen.getByRole('button');
+        fireEvent.click(menuButton);
+
+        // Click create rule menu item
+        const createRuleMenuItem = screen.getByTestId('create-rule-menu-item');
+        fireEvent.click(createRuleMenuItem);
+
+        expect(mockOpenCreateDialog).toHaveBeenCalledWith(testRoleName);
+        expect(mockOpenCreateDialog).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls openDeleteRoleDialog with roleName when delete role is clicked', () => {
+        CustomRender(
+            <RoleActionMenu
+                roleName={testRoleName}
+                openCreateDialog={mockOpenCreateDialog}
+                openDeleteRoleDialog={mockOpenDeleteRoleDialog}
+            />,
+        );
+
+        // Open menu
+        const menuButton = screen.getByRole('button');
+        fireEvent.click(menuButton);
+
+        // Click delete role menu item
+        const deleteRoleMenuItem = screen.getByTestId('delete-role-menu-item');
+        fireEvent.click(deleteRoleMenuItem);
+
+        expect(mockOpenDeleteRoleDialog).toHaveBeenCalledWith(testRoleName);
+        expect(mockOpenDeleteRoleDialog).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders with different role names', () => {
+        const differentRoleName = 'admin-role';
+
+        CustomRender(
+            <RoleActionMenu
+                roleName={differentRoleName}
+                openCreateDialog={mockOpenCreateDialog}
+                openDeleteRoleDialog={mockOpenDeleteRoleDialog}
+            />,
+        );
+
+        const menuButton = screen.getByRole('button');
+        fireEvent.click(menuButton);
+
+        const createRuleMenuItem = screen.getByTestId('create-rule-menu-item');
+        fireEvent.click(createRuleMenuItem);
+
+        expect(mockOpenCreateDialog).toHaveBeenCalledWith(differentRoleName);
+    });
+});

--- a/src/app/[locale]/settings/_components/role-settings/RoleActionMenu.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RoleActionMenu.tsx
@@ -10,7 +10,7 @@ export function RoleActionMenu({
     openDeleteRoleDialog,
 }: {
     roleName: string;
-    openCreateDialog: (roleName: string | null) => void;
+    openCreateDialog: (roleName: string) => void;
     openDeleteRoleDialog: (roleName: string) => void;
 }) {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);

--- a/src/app/[locale]/settings/_components/role-settings/RoleActionMenu.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RoleActionMenu.tsx
@@ -1,0 +1,46 @@
+import { IconButton, Menu, MenuItem } from '@mui/material';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import { useState } from 'react';
+import { useTranslations } from 'use-intl';
+import { red } from '@mui/material/colors';
+
+export function RoleActionMenu({
+    roleName,
+    openCreateDialog,
+    openDeleteRoleDialog,
+}: {
+    roleName: string;
+    openCreateDialog: (roleName: string | null) => void;
+    openDeleteRoleDialog: (roleName: string) => void;
+}) {
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const t = useTranslations('pages.settings.rules');
+
+    const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleMenuClose = () => {
+        setAnchorEl(null);
+    };
+
+    return (
+        <>
+            <IconButton onClick={handleMenuOpen}>
+                <MoreVertIcon />
+            </IconButton>
+            <Menu id="role-actions-menu" anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleMenuClose}>
+                <MenuItem onClick={() => openCreateDialog(roleName)} data-testid="create-rule-menu-item">
+                    {t('createRule.title')}
+                </MenuItem>
+                <MenuItem
+                    sx={{ color: red[500] }}
+                    onClick={() => openDeleteRoleDialog(roleName)}
+                    data-testid="delete-role-menu-item"
+                >
+                    {t('deleteRole.delete')}
+                </MenuItem>
+            </Menu>
+        </>
+    );
+}

--- a/src/app/[locale]/settings/_components/role-settings/RuleDialog.spec.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleDialog.spec.tsx
@@ -7,6 +7,7 @@ import { ApiResultStatus } from 'lib/util/apiResponseWrapper/apiResultStatus';
 import { mockRbacRoles } from './test-data/mockRbacRoles';
 import { ApiResponseWrapperError, wrapErrorCode, wrapSuccess } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 import { EnvProvider } from 'app/EnvProvider';
+import { RoleOptions } from './RuleSettings';
 
 jest.mock('./../../../../../lib/services/rbac-service/RbacActions');
 jest.mock('next-intl', () => ({
@@ -35,7 +36,9 @@ const conflictRule = {
 };
 const newName = 'newRoleName';
 
-const availableRoles = [...new Set(mockRbacRoles.roles.map((role) => role.role))];
+const availableRoles: RoleOptions[] = [
+    ...new Map((mockRbacRoles?.roles ?? []).map((role) => [role.role, { name: role.role }])).values(),
+];
 
 async function renderRuleDialog(rule: DialogRbacRule) {
     const onClose = jest.fn();

--- a/src/app/[locale]/settings/_components/role-settings/RuleDialog.spec.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleDialog.spec.tsx
@@ -23,21 +23,21 @@ jest.mock('./../../../../../lib/services/envAction', () => ({
 }));
 
 const notLastRuleForRole: DialogRbacRule = {
-    ...mockRbacRoles.roles[0],
+    ...mockRbacRoles.rules[0],
     isOnlyRuleForRole: false,
 };
 const lastRuleForRole: DialogRbacRule = {
-    ...mockRbacRoles.roles[2],
+    ...mockRbacRoles.rules[2],
     isOnlyRuleForRole: true,
 };
 const conflictRule = {
-    ...mockRbacRoles.roles[3],
+    ...mockRbacRoles.rules[3],
     isOnlyRuleForRole: true,
 };
 const newName = 'newRoleName';
 
 const availableRoles: RoleOptions[] = [
-    ...new Map((mockRbacRoles?.roles ?? []).map((role) => [role.role, { name: role.role }])).values(),
+    ...new Map((mockRbacRoles?.rules ?? []).map((role) => [role.role, { name: role.role }])).values(),
 ];
 
 async function renderRuleDialog(rule: DialogRbacRule) {

--- a/src/app/[locale]/settings/_components/role-settings/RuleDialog.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleDialog.tsx
@@ -12,7 +12,7 @@ import { useNotificationSpawner } from 'lib/hooks/UseNotificationSpawner';
 import { RuleForm, RuleFormModel } from 'app/[locale]/settings/_components/role-settings/RuleForm';
 import { BaSyxRbacRule } from 'lib/services/rbac-service/types/RbacServiceData';
 import { KeycloakHint } from 'app/[locale]/settings/_components/role-settings/HintDialogContent';
-import { RuleDeleteDialog } from 'app/[locale]/settings/_components/role-settings/RuleDeleteDialog';
+import { DeleteRuleDialogContent } from 'app/[locale]/settings/_components/role-settings/DeleteRuleDialogContent';
 import { CopyButton } from 'components/basics/CopyButton';
 import { RoleOptions } from './RuleSettings';
 
@@ -168,7 +168,7 @@ export const RuleDialog = ({ onClose, reloadRules, open, rule, availableRoles }:
                 );
             case 'delete':
                 return (
-                    <RuleDeleteDialog rule={rule} onCancelDialog={() => setDialogMode('view')} onDelete={onDelete} />
+                    <DeleteRuleDialogContent rule={rule} onCancelDialog={() => setDialogMode('view')} onDelete={onDelete} />
                 );
             case 'create-hint':
                 return <KeycloakHint hint="create" onClose={onClose} />;

--- a/src/app/[locale]/settings/_components/role-settings/RuleDialog.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleDialog.tsx
@@ -14,6 +14,7 @@ import { BaSyxRbacRule } from 'lib/services/rbac-service/types/RbacServiceData';
 import { KeycloakHint } from 'app/[locale]/settings/_components/role-settings/HintDialogContent';
 import { RuleDeleteDialog } from 'app/[locale]/settings/_components/role-settings/RuleDeleteDialog';
 import { CopyButton } from 'components/basics/CopyButton';
+import { RoleOptions } from './RuleSettings';
 
 export type DialogRbacRule = BaSyxRbacRule & {
     // If this rule is the only rule for the role
@@ -25,7 +26,7 @@ type RuleDialogProps = {
     readonly reloadRules: () => Promise<void>;
     readonly open: boolean;
     readonly rule: DialogRbacRule;
-    readonly availableRoles: string[];
+    readonly availableRoles: RoleOptions[];
 };
 
 type DialogMode = 'edit' | 'view' | 'delete' | 'create-hint' | 'delete-hint';
@@ -37,8 +38,8 @@ export const RuleDialog = ({ onClose, reloadRules, open, rule, availableRoles }:
     const notificationSpawner = useNotificationSpawner();
 
     async function updateDialogModeForNewRule(newData: RuleFormModel) {
-        const isRuleForNewRole = !availableRoles.includes(newData.role);
-        const wasLastRuleForOldRole = rule.isOnlyRuleForRole && rule.role !== newData.role;
+        const isRuleForNewRole = !availableRoles.some((option) => option.name === newData.role.name);
+        const wasLastRuleForOldRole = rule.isOnlyRuleForRole && rule.role !== newData.role.name;
 
         if (isRuleForNewRole) {
             setDialogMode('create-hint');

--- a/src/app/[locale]/settings/_components/role-settings/RuleForm.spec.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleForm.spec.tsx
@@ -18,7 +18,7 @@ jest.mock('./../../../../../lib/services/rbac-service/RbacActions');
  */
 
 const availableRoles: RoleOptions[] = [
-    ...new Map((mockRbacRoles?.roles ?? []).map((role) => [role.role, { name: role.role }])).values(),
+    ...new Map((mockRbacRoles?.rules ?? []).map((role) => [role.role, { name: role.role }])).values(),
 ];
 
 describe('RuleForm', () => {

--- a/src/app/[locale]/settings/_components/role-settings/RuleForm.spec.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleForm.spec.tsx
@@ -6,6 +6,7 @@ import { act } from 'react';
 import { BaSyxRbacRule } from 'lib/services/rbac-service/types/RbacServiceData';
 import * as rbacActions from 'lib/services/rbac-service/RbacActions';
 import { mockRbacRoles } from './test-data/mockRbacRoles';
+import { RoleOptions } from './RuleSettings';
 
 jest.mock('next-intl', () => ({
     useTranslations: () => (key: string) => key,
@@ -16,7 +17,9 @@ jest.mock('./../../../../../lib/services/rbac-service/RbacActions');
   This file tests the whole RuleForm including the TargetInformationForm + WildcardOrStringArrayInput components
  */
 
-const availableRoles = [...new Set(mockRbacRoles.roles.map((role) => role.role))];
+const availableRoles: RoleOptions[] = [
+    ...new Map((mockRbacRoles?.roles ?? []).map((role) => [role.role, { name: role.role }])).values(),
+];
 
 describe('RuleForm', () => {
     const mockRule: BaSyxRbacRule = {
@@ -133,7 +136,7 @@ describe('RuleForm', () => {
             expect(defaultProps.onSubmit.mock.calls[0][0]).toEqual(
                 expect.objectContaining({
                     action: 'READ',
-                    role: 'Admin',
+                    role: { name: 'Admin' },
                     type: 'aas-environment',
                     targetInformation: expect.objectContaining({
                         'aas-environment': expect.objectContaining({

--- a/src/app/[locale]/settings/_components/role-settings/RuleForm.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleForm.tsx
@@ -13,7 +13,7 @@ import {
 import CloseIcon from '@mui/icons-material/Close';
 import { useTranslations } from 'next-intl';
 import { BaSyxRbacRule, rbacRuleActions, rbacRuleTargets } from 'lib/services/rbac-service/types/RbacServiceData';
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import CheckIcon from '@mui/icons-material/Check';
 import { TargetInformationForm } from 'app/[locale]/settings/_components/role-settings/target-information/TargetInformationForm';
 import { Controller, useForm } from 'react-hook-form';
@@ -67,8 +67,11 @@ export const RuleForm = ({ onCancel, onSubmit, rule, title, availableRoles, sele
     return (
         <form onSubmit={handleSubmit(onSubmit)}>
             <DialogContent>
-                <Typography variant="h2" color="primary" mb="1em">
+                <Typography variant="h2" color="primary">
                     {title}
+                </Typography>
+                <Typography color="text.secondary" mb="1em">
+                    {selectedRole ? t('createRule.subtitle2', { role: selectedRole }) : t('createRule.subtitle')}
                 </Typography>
                 <Box display="flex" flexDirection="column">
                     <Typography variant="h5">{t('tableHeader.name')}</Typography>
@@ -104,6 +107,7 @@ export const RuleForm = ({ onCancel, onSubmit, rule, title, availableRoles, sele
                                             {...params}
                                             variant="outlined"
                                             error={!!error}
+                                            placeholder={t('createRule.placeholderText')}
                                             {...field}
                                             helperText={error ? error.message : ''}
                                             disabled={!!selectedRole}

--- a/src/app/[locale]/settings/_components/role-settings/RuleForm.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleForm.tsx
@@ -65,7 +65,11 @@ export function RuleForm({ onCancel, onSubmit, rule, title, availableRoles, sele
             role: selectedRole ? { name: selectedRole } : mapBaSyxRbacRuleToFormModel(rule as BaSyxRbacRule).role,
         });
     }, [rule, selectedRole, reset]);
-
+    
+    function getInputValueTitle(inputValue: string): string {
+        return `${t('buttons.add')} "${inputValue}"`;
+    }
+    
     return (
         <form onSubmit={handleSubmit(onSubmit)}>
             <DialogContent>
@@ -97,16 +101,9 @@ export function RuleForm({ onCancel, onSubmit, rule, title, availableRoles, sele
                                     freeSolo
                                     options={availableRoles}
                                     value={field.value || null}
-                                    onChange={(_, newValue) => {
-                                        if (typeof newValue === 'string') {
-                                            field.onChange({ name: newValue });
-                                        } else {
-                                            field.onChange(newValue);
-                                        }
-                                    }}
                                     onInputChange={(_, newValue, reason) => {
                                         if (reason === 'input' || reason === 'clear') {
-                                            field.onChange({ name: newValue });
+                                            field.onChange(newValue);
                                         }
                                     }}
                                     filterOptions={(options, params) => {
@@ -117,7 +114,7 @@ export function RuleForm({ onCancel, onSubmit, rule, title, availableRoles, sele
                                         if (inputValue !== '' && !isExisting) {
                                             filtered.push({
                                                 name: inputValue,
-                                                title: `${t('buttons.add')} "${inputValue}"`,
+                                                title: getInputValueTitle(inputValue),
                                             });
                                         }
                                         return filtered;
@@ -125,9 +122,6 @@ export function RuleForm({ onCancel, onSubmit, rule, title, availableRoles, sele
                                     getOptionLabel={(option) => {
                                         if (typeof option === 'string') {
                                             return option;
-                                        }
-                                        if (option.title) {
-                                            return option.title;
                                         }
                                         return option.name;
                                     }}
@@ -142,6 +136,14 @@ export function RuleForm({ onCancel, onSubmit, rule, title, availableRoles, sele
                                             disabled={!!selectedRole}
                                         />
                                     )}
+                                    renderOption={(props, option) => {
+                                        const { key, ...optionProps } = props;
+                                        return (
+                                            <li key={key} {...optionProps}>
+                                                {option.title ?? option.name}
+                                            </li>
+                                        );
+                                    }}
                                     disabled={!!selectedRole}
                                 />
                             </FormControl>

--- a/src/app/[locale]/settings/_components/role-settings/RuleForm.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleForm.tsx
@@ -25,6 +25,7 @@ type RuleDialogProps = {
     readonly rule: BaSyxRbacRule;
     readonly title: string;
     readonly availableRoles: string[];
+    readonly selectedRole?: string | null;
 };
 
 export type ArrayOfIds = [{ id: string }];
@@ -46,16 +47,22 @@ export type RuleFormModel = {
     targetInformation: TargetInformationFormModel;
 };
 
-export const RuleForm = ({ onCancel, onSubmit, rule, title, availableRoles }: RuleDialogProps) => {
+export const RuleForm = ({ onCancel, onSubmit, rule, title, availableRoles, selectedRole }: RuleDialogProps) => {
     const t = useTranslations('pages.settings.rules');
 
     const { control, handleSubmit, setValue, getValues, reset } = useForm({
-        defaultValues: mapBaSyxRbacRuleToFormModel(rule as BaSyxRbacRule),
+        defaultValues: {
+            ...mapBaSyxRbacRuleToFormModel(rule as BaSyxRbacRule),
+            role: selectedRole ?? mapBaSyxRbacRuleToFormModel(rule as BaSyxRbacRule).role,
+        },
     });
 
     useEffect(() => {
-        reset(mapBaSyxRbacRuleToFormModel(rule as BaSyxRbacRule));
-    }, [rule]);
+        reset({
+            ...mapBaSyxRbacRuleToFormModel(rule as BaSyxRbacRule),
+            role: selectedRole ?? mapBaSyxRbacRuleToFormModel(rule as BaSyxRbacRule).role,
+        });
+    }, [rule, selectedRole, reset]);
 
     return (
         <form onSubmit={handleSubmit(onSubmit)}>
@@ -97,9 +104,12 @@ export const RuleForm = ({ onCancel, onSubmit, rule, title, availableRoles }: Ru
                                             {...params}
                                             variant="outlined"
                                             error={!!error}
+                                            {...field}
                                             helperText={error ? error.message : ''}
+                                            disabled={!!selectedRole}
                                         />
                                     )}
+                                    disabled={!!selectedRole}
                                 />
                             </FormControl>
                         )}

--- a/src/app/[locale]/settings/_components/role-settings/RuleForm.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleForm.tsx
@@ -13,7 +13,7 @@ import {
 import CloseIcon from '@mui/icons-material/Close';
 import { useTranslations } from 'next-intl';
 import { BaSyxRbacRule, rbacRuleActions, rbacRuleTargets } from 'lib/services/rbac-service/types/RbacServiceData';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import CheckIcon from '@mui/icons-material/Check';
 import { TargetInformationForm } from 'app/[locale]/settings/_components/role-settings/target-information/TargetInformationForm';
 import { Controller, useForm } from 'react-hook-form';
@@ -47,7 +47,7 @@ export type RuleFormModel = {
     targetInformation: TargetInformationFormModel;
 };
 
-export const RuleForm = ({ onCancel, onSubmit, rule, title, availableRoles, selectedRole }: RuleDialogProps) => {
+export function RuleForm({ onCancel, onSubmit, rule, title, availableRoles, selectedRole }: RuleDialogProps) {
     const t = useTranslations('pages.settings.rules');
 
     const { control, handleSubmit, setValue, getValues, reset } = useForm({
@@ -159,4 +159,4 @@ export const RuleForm = ({ onCancel, onSubmit, rule, title, availableRoles, sele
             </DialogActions>
         </form>
     );
-};
+}

--- a/src/app/[locale]/settings/_components/role-settings/RuleForm.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleForm.tsx
@@ -65,11 +65,11 @@ export function RuleForm({ onCancel, onSubmit, rule, title, availableRoles, sele
             role: selectedRole ? { name: selectedRole } : mapBaSyxRbacRuleToFormModel(rule as BaSyxRbacRule).role,
         });
     }, [rule, selectedRole, reset]);
-    
+
     function getInputValueTitle(inputValue: string): string {
         return `${t('buttons.add')} "${inputValue}"`;
     }
-    
+
     return (
         <form onSubmit={handleSubmit(onSubmit)}>
             <DialogContent>
@@ -101,9 +101,16 @@ export function RuleForm({ onCancel, onSubmit, rule, title, availableRoles, sele
                                     freeSolo
                                     options={availableRoles}
                                     value={field.value || null}
+                                    onChange={(_, newValue) => {
+                                        if (typeof newValue === 'string') {
+                                            field.onChange({ name: newValue });
+                                        } else {
+                                            field.onChange(newValue);
+                                        }
+                                    }}
                                     onInputChange={(_, newValue, reason) => {
                                         if (reason === 'input' || reason === 'clear') {
-                                            field.onChange(newValue);
+                                            field.onChange({ name: newValue });
                                         }
                                     }}
                                     filterOptions={(options, params) => {

--- a/src/app/[locale]/settings/_components/role-settings/RuleSettings.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleSettings.tsx
@@ -134,8 +134,8 @@ export const RuleSettings = () => {
             <CreateRuleDialog
                 open={createDialogOpen}
                 onClose={() => {
-                    setSelectedRole('');
                     setCreateDialogOpen(false);
+                    setSelectedRole('');
                 }}
                 reloadRules={loadRbacData}
                 availableRoles={availableRoles}
@@ -144,8 +144,8 @@ export const RuleSettings = () => {
             <DeleteRoleDialog
                 open={deleteRoleDialogOpen}
                 onClose={() => {
-                    setSelectedRole('');
                     setDeleteRoleDialogOpen(false);
+                    setSelectedRole('');
                 }}
                 reloadRules={loadRbacData}
                 roleName={selectedRole}

--- a/src/app/[locale]/settings/_components/role-settings/RuleSettings.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleSettings.tsx
@@ -133,20 +133,16 @@ export const RuleSettings = () => {
             />
             <CreateRuleDialog
                 open={createDialogOpen}
-                onClose={() => {
-                    setCreateDialogOpen(false);
-                    setSelectedRole('');
-                }}
+                onClose={() => setCreateDialogOpen(false)}
+                afterClose={() => setSelectedRole('')}
                 reloadRules={loadRbacData}
                 availableRoles={availableRoles}
                 selectedRole={selectedRole}
             />
             <DeleteRoleDialog
                 open={deleteRoleDialogOpen}
-                onClose={() => {
-                    setDeleteRoleDialogOpen(false);
-                    setSelectedRole('');
-                }}
+                onClose={() => setDeleteRoleDialogOpen(false)}
+                afterClose={() => setSelectedRole('')}
                 reloadRules={loadRbacData}
                 roleName={selectedRole}
                 rules={groupedRules[selectedRole] ?? []}

--- a/src/app/[locale]/settings/_components/role-settings/RuleSettings.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleSettings.tsx
@@ -68,6 +68,10 @@ export const RuleSettings = () => {
         setCreateDialogOpen(true);
     };
 
+    const openDeleteRoleDialog = (_roleName: string) => {
+        throw new Error('Delete role dialog is not implemented yet');
+    };
+
     function groupRulesByRole(): Record<string, BaSyxRbacRule[]> {
         if (!rbacRoles) return {};
         return rbacRoles.roles.reduce(
@@ -109,6 +113,7 @@ export const RuleSettings = () => {
                                     rules={rules}
                                     openDetailDialog={openDetailDialog}
                                     openCreateDialog={openCreateDialog}
+                                    openDeleteRoleDialog={openDeleteRoleDialog}
                                 />
                             ))}
                         </Box>

--- a/src/app/[locale]/settings/_components/role-settings/RuleSettings.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleSettings.tsx
@@ -13,6 +13,10 @@ import { CreateRuleDialog, defaultRbacRule } from 'app/[locale]/settings/_compon
 import { RoleAccordion } from './RoleAccordion';
 
 const DEFAULT_RBAC_RULE = { ...defaultRbacRule, isOnlyRuleForRole: false };
+export type RoleOptions = {
+    readonly name: string;
+    readonly title?: string;
+};
 
 export const RuleSettings = () => {
     const t = useTranslations('pages.settings.rules');
@@ -25,7 +29,13 @@ export const RuleSettings = () => {
     const { showError } = useShowError();
 
     // all available role names
-    const availableRoles = [...new Set(rbacRoles?.roles.map((role) => role.role))];
+    /**
+     * Extracts available roles as an array of objects with 'role' and 'title' properties.
+     * @type {RoleOptions}[]}
+     */
+    const availableRoles: RoleOptions[] = [
+        ...new Map((rbacRoles?.roles ?? []).map((role) => [role.role, { name: role.role }])).values(),
+    ];
 
     async function loadRbacData() {
         setIsLoading(true);

--- a/src/app/[locale]/settings/_components/role-settings/RuleSettings.tsx
+++ b/src/app/[locale]/settings/_components/role-settings/RuleSettings.tsx
@@ -21,6 +21,7 @@ export const RuleSettings = () => {
     const [selectedRule, setSelectedRule] = useState<DialogRbacRule>();
     const [rbacRoles, setRbacRoles] = useState<RbacRolesFetchResult>();
     const [isLoading, setIsLoading] = useState(false);
+    const [selectedRole, setSelectedRole] = useState<string | null>(null);
     const { showError } = useShowError();
 
     // all available role names
@@ -50,6 +51,11 @@ export const RuleSettings = () => {
 
         setSelectedRule(updatedEntry);
         setRuleDetailDialogOpen(true);
+    };
+
+    const openCreateDialog = (roleName: string | null) => {
+        setSelectedRole(roleName);
+        setCreateDialogOpen(true);
     };
 
     function groupRulesByRole(): Record<string, BaSyxRbacRule[]> {
@@ -92,6 +98,7 @@ export const RuleSettings = () => {
                                     roleName={roleName}
                                     rules={rules}
                                     openDetailDialog={openDetailDialog}
+                                    openCreateDialog={openCreateDialog}
                                 />
                             ))}
                         </Box>
@@ -108,9 +115,13 @@ export const RuleSettings = () => {
             />
             <CreateRuleDialog
                 open={createDialogOpen}
-                onClose={() => setCreateDialogOpen(false)}
+                onClose={() => {
+                    setSelectedRole(null);
+                    setCreateDialogOpen(false);
+                }}
                 reloadRules={loadRbacData}
                 availableRoles={availableRoles}
+                selectedRole={selectedRole}
             />
         </>
     );

--- a/src/app/[locale]/settings/_components/role-settings/test-data/mockRbacRoles.ts
+++ b/src/app/[locale]/settings/_components/role-settings/test-data/mockRbacRoles.ts
@@ -1,7 +1,7 @@
-import { RbacRolesFetchResult } from 'lib/services/rbac-service/types/RbacServiceData';
+import { RbacRulesFetchResult } from 'lib/services/rbac-service/types/RbacServiceData';
 
-export const mockRbacRoles: RbacRolesFetchResult = {
-    roles: [
+export const mockRbacRoles: RbacRulesFetchResult = {
+    rules: [
         {
             idShort: 'roleId1',
             role: 'Admin-Role',

--- a/src/lib/api/graphql/catalogActions.ts
+++ b/src/lib/api/graphql/catalogActions.ts
@@ -58,8 +58,6 @@ function buildFilterInput(filters?: FilterQuery[]): string {
         `);
     }
 
-    console.log(filterArray);
-
     if (filterArray.length === 0) {
         return '';
     }
@@ -68,8 +66,6 @@ function buildFilterInput(filters?: FilterQuery[]): string {
 
 export async function searchProducts(filters?: FilterQuery[]): Promise<ApiResponseWrapper<SearchResponseEntry[]>> {
     const queryString = searchQuery(buildFilterInput(filters));
-    console.log(queryString);
-
     const query = gql(queryString);
     try {
         const { data } = await client.query<SearchResponse>({

--- a/src/lib/services/rbac-service/RbacRulesService.spec.ts
+++ b/src/lib/services/rbac-service/RbacRulesService.spec.ts
@@ -20,7 +20,7 @@ describe('RbacRulesService', () => {
             const res = await service.getRules();
             expect(res.isSuccess).toBeTruthy();
             expect(res.result?.warnings).toHaveLength(0);
-            expect(res.result?.roles).toHaveLength(2);
+            expect(res.result?.rules).toHaveLength(2);
         });
 
         it('should add warnings if unknown data is in SecuritySubmodel', async () => {

--- a/src/lib/services/rbac-service/RbacRulesService.ts
+++ b/src/lib/services/rbac-service/RbacRulesService.ts
@@ -7,7 +7,7 @@ import { SubmodelElementCollection } from '@aas-core-works/aas-core3.0-typescrip
 import { envs } from 'lib/env/MnestixEnv';
 import { RuleParseError, ruleToIdShort, ruleToSubmodelElement, submodelToRule } from './RuleHelpers';
 import logger, { logResponseDebug, logResponseInfo, logResponseWarn } from 'lib/util/Logger';
-import { BaSyxRbacRule, RbacRolesFetchResult } from 'lib/services/rbac-service/types/RbacServiceData';
+import { BaSyxRbacRule, RbacRulesFetchResult } from 'lib/services/rbac-service/types/RbacServiceData';
 
 const SEC_SUB_ID = 'SecuritySubmodel';
 /**
@@ -72,7 +72,7 @@ export class RbacRulesService {
     /**
      * Get all rbac rules
      */
-    async getRules(): Promise<ApiResponseWrapper<RbacRolesFetchResult>> {
+    async getRules(): Promise<ApiResponseWrapper<RbacRulesFetchResult>> {
         const response = await this.securitySubmodelRepositoryClient.getSubmodelById(SEC_SUB_ID);
         const secSM = response.result;
         if (!response.isSuccess) {
@@ -106,7 +106,7 @@ export class RbacRulesService {
             Roles: roles.length,
             Warnings: warnings,
         });
-        return wrapSuccess({ roles: roles, warnings: warnings });
+        return wrapSuccess({ rules: roles, warnings: warnings });
     }
 
     /**
@@ -189,7 +189,7 @@ export class RbacRulesService {
             return false;
         }
 
-        return !rules.result.roles.find((e) => e.idShort === idShort);
+        return !rules.result.rules.find((e) => e.idShort === idShort);
     }
 }
 

--- a/src/lib/services/rbac-service/types/RbacServiceData.ts
+++ b/src/lib/services/rbac-service/types/RbacServiceData.ts
@@ -24,8 +24,8 @@ export type BaSyxRbacRule = {
     role: string;
     action: (typeof rbacRuleActions)[number];
 };
-export type RbacRolesFetchResult = {
-    roles: BaSyxRbacRule[];
+export type RbacRulesFetchResult = {
+    rules: BaSyxRbacRule[];
     warnings: string[][];
 };
 

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -17,7 +17,7 @@
     },
     "assetNotFound": {
       "header": "Verwaltungsschale konnte nicht geladen werden.",
-      "text": "Es konnte keine Verwaltungsschale für die angegebene ID \"{id}\" geladen werden.",
+      "text": "Es konnte keine Verwaltungsschale für die angegebene ID ''{id}'' geladen werden.",
       "toHome": "Zur Startseite"
     },
     "authentication": {
@@ -105,7 +105,7 @@
     },
     "noSearchResult": {
       "header": "Keine Daten gefunden",
-      "noDataFound": "Es wurden keine Daten für \"{name}\" gefunden.",
+      "noDataFound": "Es wurden keine Daten für ''{name}'' gefunden.",
       "toHomeButton": "Zur Startseite"
     },
     "propertyComponent": {
@@ -380,9 +380,9 @@
           "title": "Wie Sie Ihre Asset ID mit Ihrem Repository verbinden"
         },
         "errors": {
-          "idStructureError": "Fehler beim speichern von \"{name}\" ({reason}).",
+          "idStructureError": "Fehler beim speichern von ''{name}'' ({reason}).",
           "invalidIri": "Muss eine valide IRI sein. Z.B. https://example.com/",
-          "invalidIriPart": "Muss als Teil einer IRI funktionieren können (kein \"/\", Leer- und Sonderzeichen)"
+          "invalidIriPart": "Muss als Teil einer IRI funktionieren können (keine Schrägstriche, Leer- und Sonderzeichen erlaubt)"
         },
         "labels": {
           "dynamicPart": "dynamischer Teil",
@@ -415,7 +415,7 @@
           "title": "Neue Berechtigung hinzufügen"
         },
         "deleteRole": {
-          "delete": "",
+          "delete": "Rolle löschen",
           "description": "",
           "header": "",
           "partiallySuccess": "",
@@ -478,7 +478,7 @@
       "createNew": "Neu erstellen",
       "custom": "Custom",
       "defaultValue": "Defaultwert",
-      "deleteTemplateQuestion": "Template \"{name}\" unwiderruflich löschen?",
+      "deleteTemplateQuestion": "Template ''{name}'' unwiderruflich löschen?",
       "displayName": "Anzeigename",
       "emptyCustom": "Leer (Custom)",
       "emptyCustomDescription": "Basiert auf keinem standardisierten Template",
@@ -507,7 +507,7 @@
       "title": "Templates",
       "validation": {
         "errors": {
-          "invalidDate": "Muss ein gültiges Datum sein, im Format \"yyyy-mm-dd\"",
+          "invalidDate": "Muss ein gültiges Datum sein, im Format ''yyyy-mm-dd''",
           "invalidLong": "Muss eine valide Zahl sein"
         }
       }

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -416,10 +416,10 @@
         },
         "deleteRole": {
           "delete": "Rolle löschen",
-          "description": "",
-          "header": "",
-          "partiallySuccess": "",
-          "success": ""
+          "description": "Die Rolle ''{roleName}'' enthält {count} Rechte. Wollen Sie die gesamte Rolle mit allen Rechten löschen?",
+          "header": "Gesamte Rolle löschen",
+          "partiallySuccess": "{count} von {total} Rechte wurden gelöscht. Die Rolle existiert weiterhin mit den restlichen Rechten!",
+          "success": "Rolle ''{roleName}'' wurde erfogreich gelöscht."
         },
         "deleteRule": {
           "question": "Regel unwiderruflich löschen?",

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -1,10 +1,5 @@
 {
   "components": {
-    "constructionDialog": {
-      "title": "In Bearbeitung",
-      "message": "Diese Funktion befindet sich derzeit im Aufbau und wird in Kürze verfügbar sein.",
-      "buttonText": "Schließen"
-    },
     "addressComponent": {
       "VAT": "USt-IdNr.",
       "addressTypes": {
@@ -71,6 +66,11 @@
         "year": "{count, plural, =0 {unter einem Jahr} =1 {1 Jahr} other {# Jahre}}"
       },
       "totalCO2Equivalents": "(Bisherige) CO2 Emissionen des Produkts"
+    },
+    "constructionDialog": {
+      "buttonText": "Schließen",
+      "message": "Diese Funktion befindet sich derzeit im Aufbau und wird in Kürze verfügbar sein.",
+      "title": "In Bearbeitung"
     },
     "contactInformation": {
       "contactTypes": {
@@ -237,6 +237,7 @@
           "view": "Ansehen"
         },
         "idLabel": "ID:",
+        "noSubmodelsToLoad": "Für diese AAS existieren keine Teilmodelle.",
         "referenceCounter": {
           "count": "Anzahl",
           "elementName": "Element"
@@ -249,26 +250,25 @@
           "selectTimeframe": "Auswahl des Zeitabschnitts"
         },
         "title": "Teilmodelle",
-        "unknownModelType": "Unbekannter ModelType: {type}",
-        "noSubmodelsToLoad": "Für diese AAS existieren keine Teilmodelle."
+        "unknownModelType": "Unbekannter ModelType: {type}"
       }
     },
     "catalog": {
-      "manufacturerCatalog": "Hersteller Produktkatalog",
-      "manufacturerSelect": "Hersteller auswählen",
-      "title": "Hersteller Produktkatalog",
-      "marketplaceTitle": "VWS4LS - Marketplace",
-      "marketplaceSubtitle": "Verwaltungsschale für den Leitungssatz",
       "articleCount": "{count, plural, =1 {# Artikel} other {# Artikel}}",
-      "filter": "Filter",
-      "noSearcherWarning": "Kein AAS Searcher konfiguriert. AAS Liste wird angezeigt, Filterung ist nicht möglich.",
       "eclassCategories": {
         "15": "Instandhaltung (Dienstleistung)",
         "27": "Elektro-, Automatisierungs- und Prozessleittechnik",
         "44": "Fahrzeugtechnik, Fahrzeugkomponente",
         "default": "Kategorie "
       },
-      "searchPlaceholder": "Suche aktuell nicht verfügbar..."
+      "filter": "Filter",
+      "manufacturerCatalog": "Hersteller Produktkatalog",
+      "manufacturerSelect": "Hersteller auswählen",
+      "marketplaceSubtitle": "Verwaltungsschale für den Leitungssatz",
+      "marketplaceTitle": "VWS4LS - Marketplace",
+      "noSearcherWarning": "Kein AAS Searcher konfiguriert. AAS Liste wird angezeigt, Filterung ist nicht möglich.",
+      "searchPlaceholder": "Suche aktuell nicht verfügbar...",
+      "title": "Hersteller Produktkatalog"
     },
     "compare": {
       "addAnother": "Eine weitere AAS hinzufügen",
@@ -308,10 +308,10 @@
     "productViewer": {
       "actions": {
         "compareButton": "Vergleichen",
-        "toAasView": "AAS Ansicht",
         "download": "AAS herunterladen",
+        "downloadError": "Fehler beim Herunterladen der AAS.",
         "downloadErrorNoRepo": "Kein Repository für die ausgewählte AAS gefunden.",
-        "downloadError": "Fehler beim Herunterladen der AAS."
+        "toAasView": "AAS Ansicht"
       },
       "classification": "Produktklassifikation",
       "error": {
@@ -407,15 +407,19 @@
           "edit": "Bearbeiten",
           "save": "Speichern"
         },
-        "deleteRole": {
-          "delete": "Rolle löschen"
-        },
         "createRule": {
+          "placeholderText": "Neuer oder bestehender Rollenname",
           "saveSuccess": "Neue Regel erfolgreich gespeichert.",
-          "title": "Neue Berechtigung hinzufügen",
           "subtitle": "Füge eine Berechtigung zu einer neuen oder bereits bestehenden Rolle hinzu.",
           "subtitle2": "Füge eine Berechtigung zu der Rolle ''{role}'' hinzu.",
-          "placeholderText": "Neuer oder bestehender Rollenname"
+          "title": "Neue Berechtigung hinzufügen"
+        },
+        "deleteRole": {
+          "delete": "",
+          "description": "",
+          "header": "",
+          "partiallySuccess": "",
+          "success": ""
         },
         "deleteRule": {
           "question": "Regel unwiderruflich löschen?",

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -407,6 +407,9 @@
           "edit": "Bearbeiten",
           "save": "Speichern"
         },
+        "deleteRole": {
+          "delete": "Rolle löschen"
+        },
         "createRule": {
           "saveSuccess": "Neue Regel erfolgreich gespeichert.",
           "title": "Neue Berechtigung hinzufügen",

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -402,14 +402,17 @@
           "add": "Hinzufügen",
           "back": "Zurück",
           "cancel": "Abbrechen",
-          "create": "Regel erstellen",
+          "create": "Berechtigung hinzufügen",
           "delete": "Löschen",
           "edit": "Bearbeiten",
           "save": "Speichern"
         },
         "createRule": {
           "saveSuccess": "Neue Regel erfolgreich gespeichert.",
-          "title": "Regel erstellen"
+          "title": "Neue Berechtigung hinzufügen",
+          "subtitle": "Füge eine Berechtigung zu einer neuen oder bereits bestehenden Rolle hinzu.",
+          "subtitle2": "Füge eine Berechtigung zu der Rolle ''{role}'' hinzu.",
+          "placeholderText": "Neuer oder bestehender Rollenname"
         },
         "deleteRule": {
           "question": "Regel unwiderruflich löschen?",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -418,7 +418,7 @@
           "delete": "Delete role",
           "description": "You are about to delete the ''{roleName}'' role with {count} permissions. Are you sure you want to delete entire role?",
           "header": "Delete entire role",
-          "partiallySuccess": "{count} / {total} permissions have been deleted. The role still exists with the remaining permissions!",
+          "partiallySuccess": "{count} out of {total} permissions have been deleted. The role still exists with the remaining permissions!",
           "success": "Role ''{roleName}'' has been deleted successfully."
         },
         "deleteRule": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -402,14 +402,17 @@
           "add": "Add",
           "back": "Back",
           "cancel": "Cancel",
-          "create": "Create rule",
+          "create": "Add permission",
           "delete": "Delete",
           "edit": "Edit",
           "save": "Save"
         },
         "createRule": {
           "saveSuccess": "New rule saved successfully.",
-          "title": "Create rule"
+          "title": "Add new permission",
+          "subtitle": "Add a permission to a new or existing role.",
+          "subtitle2": "Add a permission to the role ''{role}''.",
+          "placeholderText": "New or existing role name"
         },
         "deleteRule": {
           "question": "Permanently delete this rule?",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -1,10 +1,5 @@
 {
   "components": {
-    "constructionDialog": {
-      "title": "Under Construction",
-      "message": "This feature is currently under construction and will be available soon.",
-      "buttonText": "Close"
-    },
     "addressComponent": {
       "VAT": "VAT-Number",
       "addressTypes": {
@@ -71,6 +66,11 @@
         "year": "{count, plural, =0 {less than a year} =1 {1 year} other {# years}}"
       },
       "totalCO2Equivalents": "CO2 emissions from product (so far)"
+    },
+    "constructionDialog": {
+      "buttonText": "Close",
+      "message": "This feature is currently under construction and will be available soon.",
+      "title": "Under Construction"
     },
     "contactInformation": {
       "contactTypes": {
@@ -237,6 +237,7 @@
           "view": "View"
         },
         "idLabel": "ID:",
+        "noSubmodelsToLoad": "There do not exist any submodels for this AAS.",
         "referenceCounter": {
           "count": "Count",
           "elementName": "Element"
@@ -249,26 +250,25 @@
           "selectTimeframe": "Select timeframe"
         },
         "title": "Submodels",
-        "unknownModelType": "Unknown ModelType: {type}",
-        "noSubmodelsToLoad": "There do not exist any submodels for this AAS."
+        "unknownModelType": "Unknown ModelType: {type}"
       }
     },
     "catalog": {
-      "manufacturerCatalog": "Manufacturer product catalog",
-      "manufacturerSelect": "Select manufacturer",
-      "title": "Manufacturer catalog",
-      "marketplaceTitle": "VWS4LS - Marketplace",
-      "marketplaceSubtitle": "Asset Administration Shell for Wire Harness",
       "articleCount": "{count, plural, =1 {# article} other {# articles}}",
-      "filter": "Filter",
-      "noSearcherWarning": "No AAS Searcher Configured. Showing AAS List as Fallback, filters won't work.",
       "eclassCategories": {
         "15": "Maintenance (Service)",
         "27": "Electric engineering, automation, process control engineering ",
         "44": "Automotive engineering, vehicle component",
         "default": "Category "
       },
-      "searchPlaceholder": "Search currently unavailable..."
+      "filter": "Filter",
+      "manufacturerCatalog": "Manufacturer product catalog",
+      "manufacturerSelect": "Select manufacturer",
+      "marketplaceSubtitle": "Asset Administration Shell for Wire Harness",
+      "marketplaceTitle": "VWS4LS - Marketplace",
+      "noSearcherWarning": "No AAS Searcher Configured. Showing AAS List as Fallback, filters won't work.",
+      "searchPlaceholder": "Search currently unavailable...",
+      "title": "Manufacturer catalog"
     },
     "compare": {
       "addAnother": "Add another AAS",
@@ -308,10 +308,10 @@
     "productViewer": {
       "actions": {
         "compareButton": "Compare",
-        "toAasView": "AAS View",
         "download": "Download AAS",
+        "downloadError": "Error while downloading AAS.",
         "downloadErrorNoRepo": "No repository found for the selected AAS.",
-        "downloadError": "Error while downloading AAS."
+        "toAasView": "AAS View"
       },
       "classification": "Classification",
       "error": {
@@ -407,15 +407,19 @@
           "edit": "Edit",
           "save": "Save"
         },
-        "deleteRole": {
-          "delete": "Delete role"
-        },
         "createRule": {
+          "placeholderText": "New or existing role name",
           "saveSuccess": "New rule saved successfully.",
-          "title": "Add new permission",
           "subtitle": "Add a permission to a new or existing role.",
           "subtitle2": "Add a permission to the role ''{role}''.",
-          "placeholderText": "New or existing role name"
+          "title": "Add new permission"
+        },
+        "deleteRole": {
+          "delete": "Delete role",
+          "description": "You are about to delete the '{roleName}' role with {count} permissions. Are you sure you want to delete entire role?",
+          "header": "Delete entire role",
+          "partiallySuccess": "{count} / {total} permissions have been deleted. The role still exists with the remaining permissions!",
+          "success": "Role '{roleName}' has been deleted successfully."
         },
         "deleteRule": {
           "question": "Permanently delete this rule?",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -407,6 +407,9 @@
           "edit": "Edit",
           "save": "Save"
         },
+        "deleteRole": {
+          "delete": "Delete role"
+        },
         "createRule": {
           "saveSuccess": "New rule saved successfully.",
           "title": "Add new permission",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -17,7 +17,7 @@
     },
     "assetNotFound": {
       "header": "AAS could not be loaded.",
-      "text": "Unable to load AAS for the given ID \"{id}\"",
+      "text": "Unable to load AAS for the given ID ''{id}''",
       "toHome": "To Home"
     },
     "authentication": {
@@ -105,7 +105,7 @@
     },
     "noSearchResult": {
       "header": "No data found",
-      "noDataFound": "No data found for \"{name}\".",
+      "noDataFound": "No data found for ''{name}''.",
       "toHomeButton": "To Home"
     },
     "propertyComponent": {
@@ -165,7 +165,7 @@
     "errors": {
       "notFound": "Not found",
       "unauthorizedError": {
-        "content": "You don't have access to this resource. Log in or ask your administrator for access.",
+        "content": "You don''t have access to this resource. Log in or ask your administrator for access.",
         "title": "Unauthorized access"
       },
       "unexpectedError": "Unexpected error",
@@ -242,7 +242,7 @@
           "count": "Count",
           "elementName": "Element"
         },
-        "renderError": "Submodel can't be rendered.",
+        "renderError": "Submodel can''t be rendered.",
         "semanticIdLabel": "Semantic IDs:",
         "timeSeries": {
           "internalSegments": "Internal segments",
@@ -266,7 +266,7 @@
       "manufacturerSelect": "Select manufacturer",
       "marketplaceSubtitle": "Asset Administration Shell for Wire Harness",
       "marketplaceTitle": "VWS4LS - Marketplace",
-      "noSearcherWarning": "No AAS Searcher Configured. Showing AAS List as Fallback, filters won't work.",
+      "noSearcherWarning": "No AAS Searcher Configured. Showing AAS List as Fallback, filters won''t work.",
       "searchPlaceholder": "Search currently unavailable...",
       "title": "Manufacturer catalog"
     },
@@ -380,9 +380,9 @@
           "title": "How to connect your Asset ID with your AAS repository"
         },
         "errors": {
-          "idStructureError": "Error while saving \"{name}\" ({reason}).",
+          "idStructureError": "Error while saving ''{name}'' ({reason}).",
           "invalidIri": "Has to be a valid IRI, e.g. https://example.com/",
-          "invalidIriPart": "Has to work as part of an IRI (no \"/\", spaces or special characters)"
+          "invalidIriPart": "Has to work as part of an IRI (no slashes, spaces or special characters)"
         },
         "labels": {
           "dynamicPart": "dynamic part",
@@ -416,10 +416,10 @@
         },
         "deleteRole": {
           "delete": "Delete role",
-          "description": "You are about to delete the '{roleName}' role with {count} permissions. Are you sure you want to delete entire role?",
+          "description": "You are about to delete the ''{roleName}'' role with {count} permissions. Are you sure you want to delete entire role?",
           "header": "Delete entire role",
           "partiallySuccess": "{count} / {total} permissions have been deleted. The role still exists with the remaining permissions!",
-          "success": "Role '{roleName}' has been deleted successfully."
+          "success": "Role ''{roleName}'' has been deleted successfully."
         },
         "deleteRule": {
           "question": "Permanently delete this rule?",
@@ -435,7 +435,7 @@
         },
         "keycloakHint": {
           "acknowledge": "Acknowledge",
-          "create": "This role has not been used yet. Don't forget to configure it in Keycloak!",
+          "create": "This role has not been used yet. Don''t forget to configure it in Keycloak!",
           "delete": "Do not forget to delete this role in Keycloak as well!",
           "title": "Update Keycloak"
         },
@@ -478,7 +478,7 @@
       "createNew": "Create new",
       "custom": "Custom",
       "defaultValue": "Default value",
-      "deleteTemplateQuestion": "Delete template \"{name}\" irretrievably?",
+      "deleteTemplateQuestion": "Delete template ''{name}'' irretrievably?",
       "displayName": "Display name",
       "emptyCustom": "Empty (Custom)",
       "emptyCustomDescription": "Is not based upon a standardized template",
@@ -507,7 +507,7 @@
       "title": "Templates",
       "validation": {
         "errors": {
-          "invalidDate": "Has to be a valid date in format \"yyyy-mm-dd\"",
+          "invalidDate": "Has to be a valid date in format ''yyyy-mm-dd''",
           "invalidLong": "Has to be a valid long"
         }
       }

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -402,14 +402,17 @@
           "add": "Añadir",
           "back": "Atrás",
           "cancel": "Cancelar",
-          "create": "Crear regla",
+          "create": "Crear regla // Translate this",
           "delete": "Eliminar",
           "edit": "Editar",
           "save": "Guardar"
         },
         "createRule": {
           "saveSuccess": "Nueva regla guardada con éxito.",
-          "title": "Crear regla"
+          "title": "Crear regla // Translate this",
+          "subtitle": "Add a permission to a new or existing role. // Translate this",
+          "subtitle2": "Add a permission to the role ''{role}''. // Translate this",
+          "placeholderText": "Nueva oda existante amo rola // Translate this"
         },
         "deleteRule": {
           "question": "¿Desea borrar esta regla permanentemente?",

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -1,10 +1,5 @@
 {
   "components": {
-    "constructionDialog": {
-      "title": "En Construcción",
-      "message": "Esta función está actualmente en construcción y estará disponible próximamente.",
-      "buttonText": "Cerrar"
-    },
     "addressComponent": {
       "VAT": "NIF/CIF",
       "addressTypes": {
@@ -71,6 +66,11 @@
         "year": "{count, plural, =0 {inferior a un año} =1 {1 año} other {# años}}"
       },
       "totalCO2Equivalents": "Emisiones de CO2 del producto (hasta el momento)"
+    },
+    "constructionDialog": {
+      "buttonText": "Cerrar",
+      "message": "Esta función está actualmente en construcción y estará disponible próximamente.",
+      "title": "En Construcción"
     },
     "contactInformation": {
       "contactTypes": {
@@ -237,6 +237,7 @@
           "view": "Ver"
         },
         "idLabel": "ID:",
+        "noSubmodelsToLoad": "No existen submodels que cargar para este AAS.",
         "referenceCounter": {
           "count": "Recuento",
           "elementName": "Elemento"
@@ -249,26 +250,25 @@
           "selectTimeframe": "Seleccionar periodo de tiempo"
         },
         "title": "Submodels",
-        "unknownModelType": "ModelType desconocido: {type}",
-        "noSubmodelsToLoad": "No existen submodels que cargar para este AAS."
+        "unknownModelType": "ModelType desconocido: {type}"
       }
     },
     "catalog": {
-      "title": "Catálogo de productos",
-      "manufacturerCatalog": "Catálogo de productos del fabricante",
-      "manufacturerSelect": "Seleccionar fabricante",
-      "marketplaceTitle": "VWS4LS - Marketplace",
-      "marketplaceSubtitle": "Shell de administración de activos para mazos de cables",
       "articleCount": "{count, plural, =1 {# artículo} other {# artículos}}",
-      "filter": "Filtro",
-      "noSearcherWarning": "No se ha configurado el buscador AAS - Se muestra la lista AAS",
       "eclassCategories": {
         "15": "Maintenance (Service)",
         "27": "Electric engineering, automation, process control engineering ",
         "44": "Automotive engineering, vehicle component",
         "default": "Category "
       },
-      "searchPlaceholder": "Búsqueda no disponible actualmente..."
+      "filter": "Filtro",
+      "manufacturerCatalog": "Catálogo de productos del fabricante",
+      "manufacturerSelect": "Seleccionar fabricante",
+      "marketplaceSubtitle": "Shell de administración de activos para mazos de cables",
+      "marketplaceTitle": "VWS4LS - Marketplace",
+      "noSearcherWarning": "No se ha configurado el buscador AAS - Se muestra la lista AAS",
+      "searchPlaceholder": "Búsqueda no disponible actualmente...",
+      "title": "Catálogo de productos"
     },
     "compare": {
       "addAnother": "Añadir otro AAS",
@@ -308,10 +308,10 @@
     "productViewer": {
       "actions": {
         "compareButton": "Comparar",
-        "toAasView": "Vista del AAS",
         "download": "Descargar AAS",
+        "downloadError": "Error al descargar el AAS.",
         "downloadErrorNoRepo": "No se encontró ningún repositorio para el AAS seleccionado.",
-        "downloadError": "Error al descargar el AAS."
+        "toAasView": "Vista del AAS"
       },
       "classification": "Clasificación del producto",
       "error": {
@@ -407,15 +407,19 @@
           "edit": "Editar",
           "save": "Guardar"
         },
-        "deleteRole": {
-          "delete": "Borrar rol"
-        },
         "createRule": {
+          "placeholderText": "Nombre del rol nuevo o existente",
           "saveSuccess": "Nueva regla guardada con éxito.",
-          "title": "Añadir nuevo permiso",
           "subtitle": "Añade un permiso a un rol nuevo o existente.",
           "subtitle2": "Añade un permiso al rol ''{role}''.",
-          "placeholderText": "Nombre del rol nuevo o existente"
+          "title": "Añadir nuevo permiso"
+        },
+        "deleteRole": {
+          "delete": "",
+          "description": "",
+          "header": "",
+          "partiallySuccess": "",
+          "success": ""
         },
         "deleteRule": {
           "question": "¿Desea borrar esta regla permanentemente?",

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -407,6 +407,9 @@
           "edit": "Editar",
           "save": "Guardar"
         },
+        "deleteRole": {
+          "delete": "Borrar rol"
+        },
         "createRule": {
           "saveSuccess": "Nueva regla guardada con éxito.",
           "title": "Añadir nuevo permiso",

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -416,10 +416,10 @@
         },
         "deleteRole": {
           "delete": "Eliminar rol",
-          "description": "",
-          "header": "",
-          "partiallySuccess": "",
-          "success": ""
+          "description": "Está a punto de eliminar el rol ''{roleName}'' con {count} permisos. Está seguro de que desea eliminar todo el rol?",
+          "header": "Borrar todo el rol",
+          "partiallySuccess": "Se han eliminado {count} de {total} permisos. El rol aún existe con los permisos restantes.",
+          "success": "El rol ''{roleName}'' ha sido eliminado con éxito."
         },
         "deleteRule": {
           "question": "¿Desea borrar esta regla permanentemente?",

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -402,17 +402,17 @@
           "add": "Añadir",
           "back": "Atrás",
           "cancel": "Cancelar",
-          "create": "Crear regla // Translate this",
+          "create": "Añadir permiso",
           "delete": "Eliminar",
           "edit": "Editar",
           "save": "Guardar"
         },
         "createRule": {
           "saveSuccess": "Nueva regla guardada con éxito.",
-          "title": "Crear regla // Translate this",
-          "subtitle": "Add a permission to a new or existing role. // Translate this",
-          "subtitle2": "Add a permission to the role ''{role}''. // Translate this",
-          "placeholderText": "Nueva oda existante amo rola // Translate this"
+          "title": "Añadir nuevo permiso",
+          "subtitle": "Añade un permiso a un rol nuevo o existente.",
+          "subtitle2": "Añade un permiso al rol ''{role}''.",
+          "placeholderText": "Nombre del rol nuevo o existente"
         },
         "deleteRule": {
           "question": "¿Desea borrar esta regla permanentemente?",

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -17,7 +17,7 @@
     },
     "assetNotFound": {
       "header": "No se pudo cargar el AAS.",
-      "text": "No pudo cargarse el AAS para el ID \"{id}\"",
+      "text": "No pudo cargarse el AAS para el ID ''{id}''",
       "toHome": "Ir a Inicio"
     },
     "authentication": {
@@ -105,7 +105,7 @@
     },
     "noSearchResult": {
       "header": "No se encontraron datos",
-      "noDataFound": "No se encontraron datos para \"{name}\".",
+      "noDataFound": "No se encontraron datos para ''{name}''.",
       "toHomeButton": "Ir a Inicio"
     },
     "propertyComponent": {
@@ -380,9 +380,9 @@
           "title": "Como conectar su Asset ID con su repositorio de AAS"
         },
         "errors": {
-          "idStructureError": "Error al guardar \"{name}\" ({reason}).",
+          "idStructureError": "Error al guardar ''{name}'' ({reason}).",
           "invalidIri": "Debe ser un IRI válido, e.g. https://example.com/",
-          "invalidIriPart": "Debe funcionar como parte de un IRI (no \"/\", spaces or special characters)"
+          "invalidIriPart": "Debe funcionar como parte de un IRI (las barras, espacios o caracteres especiales no son válidos)"
         },
         "labels": {
           "dynamicPart": "parte dinámica",
@@ -415,7 +415,7 @@
           "title": "Añadir nuevo permiso"
         },
         "deleteRole": {
-          "delete": "",
+          "delete": "Eliminar rol",
           "description": "",
           "header": "",
           "partiallySuccess": "",
@@ -478,7 +478,7 @@
       "createNew": "Crear nuevo",
       "custom": "A medida",
       "defaultValue": "Valor predeterminado",
-      "deleteTemplateQuestion": "Desea eliminar la plantilla \"{name}\" definitivamente?",
+      "deleteTemplateQuestion": "Desea eliminar la plantilla ''{name}'' definitivamente?",
       "displayName": "Nombre a mostrar",
       "emptyCustom": "Vacío (A medida)",
       "emptyCustomDescription": "No basada en una plantilla estandarizada",
@@ -507,7 +507,7 @@
       "title": "Plantillas",
       "validation": {
         "errors": {
-          "invalidDate": "La fecha debe ser válida y seguir formato \"yyyy-mm-dd\"",
+          "invalidDate": "La fecha debe ser válida y seguir formato ''yyyy-mm-dd''",
           "invalidLong": "Debe ser un número largo válido"
         }
       }

--- a/wiki/Getting-Started-with-Developing.md
+++ b/wiki/Getting-Started-with-Developing.md
@@ -90,3 +90,5 @@ To check what other options exist to run the Mnestix Browser, see the yarn scrip
 - `yarn docker:prune` will stop all docker containers, remove them from the list and prune all volumes. Start with a
   blank slate :)
 - `yarn docker:keycloak` will setup a local keycloak instance and start Mnestix with keycloak support enabled
+- `yarn docker:rbac` will start Mnestix with dynamic RBAC support.
+- `yarn docker:proxy` will start Mnestix with a proxy configuration.


### PR DESCRIPTION
# Description

This pull request introduces changes to improve role-based access control (RBAC) functionality, enhance user interface elements, and update localization files. 

### RBAC Enhancements:
* Added a `selectedRole` property to `RoleDialogProps` in `CreateRuleDialog` and `RuleForm`, allowing pre-selection of roles during permission creation. Updated the default values and logic in `RuleForm` to handle this new property. 
* Updated `RuleSettings` to manage the `selectedRole` state and pass it to child components, ensuring seamless integration of the pre-selected role feature.

### User Interface Improvements:
* Added an "Add Permission" button to the `RoleAccordion` component, enabling users to quickly add permissions to roles. Updated layout and styling to accommodate the new button. 

### Localization Updates:
* Revised translations in `de.json`, `en.json`, and `es.json` to reflect the terminology change from "Create rule" to "Add permission" and added contextual subtitles for better user guidance. 

### Other Changes:
* Updated the `.github/CODEOWNERS` file to replace `@sirchnik-xitaso` with `@Copilot` for ownership. 
* Modified `docker-compose/compose.proxy.yml` to use a new image format and adjusted port syntax for consistency. 
* Added a new npm script `docker:proxy` in `package.json` for managing proxy-related Docker Compose configurations. 

Fixes MNE-185

## Type of change

Please delete options that are not relevant.

-   [x] Minor change (non-breaking change, e.g. documentation adaption)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [x] New and existing tests pass locally with my changes
-   [x] My changes contain no console logs
