### PR TITLE
fix(AasList)-handle-incorrect-MLP

### DIFF
--- a/src/app/[locale]/list/_components/AasListTableRow.tsx
+++ b/src/app/[locale]/list/_components/AasListTableRow.tsx
@@ -70,11 +70,19 @@ export const AasListTableRow = (props: AasTableRowProps) => {
 
     const translateListText = (property: MultiLanguageValueOnly | undefined) => {
         if (!property) return '';
-        // try the current locale first
-        const translatedString = property.find((prop) => prop[locale]);
-        // if there is any locale, better show it instead of nothing
-        const fallback = property[0] ? Object.values(property[0])[0] : '';
-        return translatedString ? translatedString[locale] : fallback;
+        try {
+            const translatedString = property.find((prop) => prop[locale]);
+            // if there is any locale, better show it instead of nothing
+            const fallback = property[0] ? Object.values(property[0])[0] : '';
+            return translatedString ? translatedString[locale] : fallback;
+        } catch (e) {
+            // if the property is a string, return it directly
+            // this can happen if the property is not a MultiLanguageValueOnly type
+            // e.g. if the property is a AAS Property type (incorrect by specification but possible) string or an error occurs
+            if (typeof property === 'string') return property;
+            console.error('Error translating property:', e);
+            return '';
+        }
     };
 
     useAsyncEffect(async () => {


### PR DESCRIPTION
# Description

This pull request introduces error handling to the `translateListText` function in the `AasListTableRow` component to handle edge cases where the input might not conform to the expected type.

### Error handling improvements:

* `src/app/[locale]/list/_components/AasListTableRow.tsx`: Updated the `translateListText` function to include a `try-catch` block. This ensures that if the `property` is not of the expected `MultiLanguageValueOnly` type or an error occurs, it handles the scenario by either returning the string directly (if the property is a string) or logging an error and returning an empty string. 

Fixes # (Issue)

## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
