### PR TITLE
fix(templateApi)-update-path-to-delete-custom-templates

### DIFF
--- a/src/lib/api/template-shell-api/templateShellApi.ts
+++ b/src/lib/api/template-shell-api/templateShellApi.ts
@@ -3,7 +3,6 @@ import { Submodel } from '@aas-core-works/aas-core3.0-typescript/types';
 
 export class TemplateShellApi {
     basePathOwnApi: string;
-    basePathCustoms: string;
     enable_authentication: boolean;
     private http: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> };
 
@@ -13,7 +12,6 @@ export class TemplateShellApi {
         http?: { fetch(url: RequestInfo, init?: RequestInit): Promise<Response> },
     ) {
         this.basePathOwnApi = `${backendApiUrl}/api/Template`;
-        this.basePathCustoms = `${backendApiUrl}/templates/custom`;
         this.enable_authentication = enable_authentication;
         this.http = http ? http : window;
     }
@@ -77,7 +75,7 @@ export class TemplateShellApi {
     public async deleteCustomById(id: string): Promise<string | number> {
         // We use the regular delete endpoint, which expects an idShort, but because of our backend interception, we saved the actual id in the idShort field earlier.
         // That's why this works.
-        const response = await this.http.fetch(`${this.basePathCustoms}/${encodeBase64(id)}`, {
+        const response = await this.http.fetch(`${this.basePathOwnApi}/${encodeBase64(id)}`, {
             method: 'DELETE',
             headers: {
                 Accept: 'application/json',


### PR DESCRIPTION
# Description

* Removed the `basePathCustoms` property and its initialization in the constructor, consolidating all API endpoints to use `basePathOwnApi`. 
* Updated the `deleteCustomById` method to use `basePathOwnApi` instead of the removed `basePathCustoms` for constructing the delete endpoint URL. 

Fixes # (Issue)

## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
