### PR TITLE
fix(docker-compose): add start-period time to aas-environment

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -126,9 +126,8 @@ services:
     healthcheck: # check the endpoint for a valid response (service ready)
       test: curl -f http://localhost:8081/actuator/health
       interval: 10s
-      timeout: 10s
-      start-period: 30s
-      retries: 6
+      timeout: 15s
+      retries: 8
     logging:
       driver: 'json-file'
       options:


### PR DESCRIPTION
# Description

The BaSyx AAS-environment takes a long time to start up and we have flaky test runs because of that.
This should delay the healthcheck long enough to always start up in time.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
