### PR TITLE
Feat(Reference): Add reference sme visualisation

### DIFF
--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/GenericSubmodelElementComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/GenericSubmodelElementComponent.tsx
@@ -11,6 +11,7 @@ import {
     MultiLanguageProperty,
     Property,
     ReferenceElement,
+    RelationshipElement,
     SubmodelElementCollection,
 } from '@aas-core-works/aas-core3.0-typescript/types';
 import { EntityComponent } from './entity-components/EntityComponent';
@@ -19,6 +20,7 @@ import { buildSubmodelElementPath } from 'lib/util/SubmodelResolverUtil';
 import { SubmodelElementComponentProps } from '../SubmodelElementComponentProps';
 import { useTranslations } from 'next-intl';
 import { ReferenceElementComponent } from './ReferenceElementComponent';
+import { RelationshipElementComponent } from './RelationshipElementComponent';
 
 type GenericSubmodelElementComponentProps = SubmodelElementComponentProps & {
     readonly submodelElementPath?: string | null;
@@ -70,6 +72,8 @@ export function GenericSubmodelElementComponent(props: GenericSubmodelElementCom
                 return <EntityComponent entity={props.submodelElement as Entity} />;
             case KeyTypes.ReferenceElement:
                 return <ReferenceElementComponent refElement={props.submodelElement as ReferenceElement} />;
+            case KeyTypes.RelationshipElement:
+                return <RelationshipElementComponent relElement={props.submodelElement as RelationshipElement} />;
             default:
                 return (
                     <Typography color="error" variant="body2">

--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/GenericSubmodelElementComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/GenericSubmodelElementComponent.tsx
@@ -10,6 +10,7 @@ import {
     KeyTypes,
     MultiLanguageProperty,
     Property,
+    ReferenceElement,
     SubmodelElementCollection,
 } from '@aas-core-works/aas-core3.0-typescript/types';
 import { EntityComponent } from './entity-components/EntityComponent';
@@ -17,6 +18,7 @@ import { getKeyType } from 'lib/util/KeyTypeUtil';
 import { buildSubmodelElementPath } from 'lib/util/SubmodelResolverUtil';
 import { SubmodelElementComponentProps } from '../SubmodelElementComponentProps';
 import { useTranslations } from 'next-intl';
+import { ReferenceElementComponent } from './ReferenceElementComponent';
 
 type GenericSubmodelElementComponentProps = SubmodelElementComponentProps & {
     readonly submodelElementPath?: string | null;
@@ -66,6 +68,8 @@ export function GenericSubmodelElementComponent(props: GenericSubmodelElementCom
                 return <MultiLanguagePropertyComponent mLangProp={props.submodelElement as MultiLanguageProperty} />;
             case KeyTypes.Entity:
                 return <EntityComponent entity={props.submodelElement as Entity} />;
+            case KeyTypes.ReferenceElement:
+                return <ReferenceElementComponent refElement={props.submodelElement as ReferenceElement} />;
             default:
                 return (
                     <Typography color="error" variant="body2">

--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/ReferenceComponent.spec.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/ReferenceComponent.spec.tsx
@@ -1,0 +1,141 @@
+import { screen } from '@testing-library/react';
+import { expect } from '@jest/globals';
+import { CustomRender } from 'test-utils/CustomRender';
+import { ReferenceComponent } from './ReferenceComponent';
+import { Reference, Key, KeyTypes, ReferenceTypes } from '@aas-core-works/aas-core3.0-typescript/types';
+
+describe('ReferenceComponent', () => {
+    const createMockKey = (value: string, type: KeyTypes): Key => new Key(type, value);
+
+    const createMockReference = (keys: Key[], type?: ReferenceTypes): Reference =>
+        new Reference(type || ReferenceTypes.ExternalReference, keys);
+
+    // Helper to create a reference with invalid data for testing error cases
+    const createPartialReference = (data: Partial<Reference>): Reference => data as Reference;
+
+    it('should display "No type specified" when reference type is undefined', () => {
+        // Create a partial reference object without type to test the component's error handling
+        const reference = createPartialReference({});
+        CustomRender(<ReferenceComponent reference={reference} />);
+
+        expect(screen.getByTestId('no-type-specified')).toBeInTheDocument();
+    });
+
+    it('should display "No reference path available" when keys are undefined', () => {
+        const reference = createPartialReference({
+            type: ReferenceTypes.ExternalReference,
+            keys: undefined,
+        });
+        CustomRender(<ReferenceComponent reference={reference} />);
+
+        expect(screen.getByTestId('no-reference-path-available')).toBeInTheDocument();
+    });
+
+    it('should display "No reference path available" when keys array is empty', () => {
+        const reference = createPartialReference({
+            type: ReferenceTypes.ExternalReference,
+            keys: [],
+        });
+        CustomRender(<ReferenceComponent reference={reference} />);
+
+        expect(screen.getByTestId('no-reference-path-available')).toBeInTheDocument();
+    });
+
+    it('should render single key correctly', () => {
+        const keys = [createMockKey('TestKey', KeyTypes.Submodel)];
+        const reference = createMockReference(keys);
+
+        CustomRender(<ReferenceComponent reference={reference} />);
+
+        expect(screen.getByText('TestKey')).toBeInTheDocument();
+        expect(screen.getByText('(20)')).toBeInTheDocument();
+        expect(screen.getByText('Reference type: 0')).toBeInTheDocument();
+    });
+
+    it('should render multiple keys with arrows between them', () => {
+        const keys = [
+            createMockKey('FirstKey', KeyTypes.AssetAdministrationShell),
+            createMockKey('SecondKey', KeyTypes.Submodel),
+            createMockKey('ThirdKey', KeyTypes.SubmodelElement),
+        ];
+        const reference = createMockReference(keys);
+
+        CustomRender(<ReferenceComponent reference={reference} />);
+
+        expect(screen.getByText('FirstKey')).toBeInTheDocument();
+        expect(screen.getByText('(1)')).toBeInTheDocument();
+        expect(screen.getByText('SecondKey')).toBeInTheDocument();
+        expect(screen.getByText('(20)')).toBeInTheDocument();
+        expect(screen.getByText('ThirdKey')).toBeInTheDocument();
+        expect(screen.getByText('(21)')).toBeInTheDocument();
+
+        // Should have 2 arrows for 3 keys
+        const arrows = document.querySelectorAll('[data-testid="ArrowForwardIcon"]');
+        expect(arrows).toHaveLength(2);
+    });
+
+    it('should style the last key differently (as primary)', () => {
+        const keys = [createMockKey('FirstKey', KeyTypes.Submodel), createMockKey('LastKey', KeyTypes.SubmodelElement)];
+        const reference = createMockReference(keys);
+
+        CustomRender(<ReferenceComponent reference={reference} />);
+
+        const lastKeyElement = screen.getByText('LastKey').closest('div');
+        const firstKeyElement = screen.getByText('FirstKey').closest('div');
+
+        // The last key should have different styling (primary color)
+        expect(lastKeyElement).toHaveStyle('background-color: rgb(25, 118, 210)'); // primary.main
+        expect(firstKeyElement).not.toHaveStyle('background-color: rgb(25, 118, 210)');
+    });
+
+    it('should handle string keys (fallback)', () => {
+        const reference = createPartialReference({
+            type: ReferenceTypes.ExternalReference,
+            keys: ['StringKey1', 'StringKey2'] as unknown as Key[],
+        });
+
+        CustomRender(<ReferenceComponent reference={reference} />);
+
+        expect(screen.getByText('StringKey1')).toBeInTheDocument();
+        expect(screen.getByText('StringKey2')).toBeInTheDocument();
+        expect(screen.getAllByText('(Unknown)')).toHaveLength(2);
+    });
+
+    it('should display correct reference type', () => {
+        const keys = [createMockKey('TestKey', KeyTypes.Submodel)];
+        const reference = createMockReference(keys, ReferenceTypes.ModelReference);
+
+        CustomRender(<ReferenceComponent reference={reference} />);
+
+        expect(screen.getByText('Reference type: 1')).toBeInTheDocument();
+    });
+
+    it('should handle null or undefined key objects', () => {
+        const reference = createPartialReference({
+            type: ReferenceTypes.ExternalReference,
+            keys: [null, undefined, createMockKey('ValidKey', KeyTypes.Submodel)] as unknown as Key[],
+        });
+
+        CustomRender(<ReferenceComponent reference={reference} />);
+
+        expect(screen.getByText('null')).toBeInTheDocument();
+        expect(screen.getByText('undefined')).toBeInTheDocument();
+        expect(screen.getByText('ValidKey')).toBeInTheDocument();
+        expect(screen.getByText('(20)')).toBeInTheDocument();
+    });
+
+    it('should display only the last key when showAllKeys is false', () => {
+        const keys = [
+            createMockKey('FirstKey', KeyTypes.AssetAdministrationShell),
+            createMockKey('SecondKey', KeyTypes.Submodel),
+            createMockKey('ThirdKey', KeyTypes.SubmodelElement),
+        ];
+        const reference = createMockReference(keys);
+        CustomRender(<ReferenceComponent reference={reference} showAllKeys={false} />);
+
+        // Only the last key should be visible
+        expect(screen.queryByText('FirstKey')).not.toBeInTheDocument();
+        expect(screen.queryByText('SecondKey')).not.toBeInTheDocument();
+        expect(screen.queryByText('ThirdKey')).toBeInTheDocument();
+    });
+});

--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/ReferenceComponent.spec.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/ReferenceComponent.spec.tsx
@@ -133,7 +133,6 @@ describe('ReferenceComponent', () => {
         const reference = createMockReference(keys);
         CustomRender(<ReferenceComponent reference={reference} showAllKeys={false} />);
 
-        // Only the last key should be visible
         expect(screen.queryByText('FirstKey')).not.toBeInTheDocument();
         expect(screen.queryByText('SecondKey')).not.toBeInTheDocument();
         expect(screen.queryByText('ThirdKey')).toBeInTheDocument();

--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/ReferenceComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/ReferenceComponent.tsx
@@ -12,15 +12,12 @@ export function ReferenceComponent(props: ReferenceProps) {
     const { showAllKeys = true } = props;
     const t = useTranslations('components.referenceComponent');
 
-    if (!props.reference.type || props.reference.type === undefined) {
-        return <Typography>{t('noTypeSpecified')}</Typography>;
+    if ((!props.reference.type && props.reference.type != 0) || props.reference.type === undefined) {
+        return <Typography data-testid="no-type-specified">{t('noTypeSpecified')}</Typography>;
     }
 
     const getKeys = () => {
         const keys = props.reference.keys;
-        if (!keys || !Array.isArray(keys) || keys.length === 0) {
-            return [];
-        }
         if (!showAllKeys) {
             return [keys[keys.length - 1]];
         } else {
@@ -29,8 +26,8 @@ export function ReferenceComponent(props: ReferenceProps) {
     };
 
     const renderReferenceKeys = () => {
-        if (!props.reference?.keys || !Array.isArray(props.reference.keys)) {
-            return <Typography>{t('noReferencePathAvailable')}</Typography>;
+        if (!props.reference?.keys || props.reference.keys.length === 0 || !Array.isArray(props.reference.keys)) {
+            return <Typography data-testid="no-reference-path-available">{t('noReferencePathAvailable')}</Typography>;
         }
 
         const keys = getKeys();

--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/ReferenceComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/ReferenceComponent.tsx
@@ -1,0 +1,90 @@
+import { Typography, Box } from '@mui/material';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import { Reference } from '@aas-core-works/aas-core3.0-typescript/types';
+
+type ReferenceProps = {
+    readonly reference: Reference;
+};
+
+export function ReferenceComponent(props: ReferenceProps) {
+    if (!props.reference.type || props.reference.type === undefined) {
+        return <Typography variant="body2">No type specified</Typography>;
+    }
+
+    const renderReferenceKeys = () => {
+        if (!props.reference?.keys || !Array.isArray(props.reference.keys)) {
+            return <Typography variant="body2">No reference path available</Typography>;
+        }
+
+        const keys = props.reference.keys;
+
+        return (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', marginTop: 1 }}>
+                {keys.map((key, index) => {
+                    const isLast = index === keys.length - 1;
+                    const keyValue = typeof key === 'object' && key !== null ? key.value : String(key);
+                    const keyType = typeof key === 'object' && key !== null ? key.type : 'Unknown';
+
+                    return (
+                        <Box key={index} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <Box
+                                sx={{
+                                    padding: '4px 8px',
+                                    borderRadius: '4px',
+                                    backgroundColor: isLast ? 'primary.main' : 'background.paper',
+                                    color: isLast ? 'primary.contrastText' : 'text.primary',
+                                    border: isLast ? 'none' : '1px solid',
+                                    borderColor: 'divider',
+                                    textAlign: 'center',
+                                    minWidth: '80px',
+                                    boxShadow: isLast ? 1 : 0.5,
+                                }}
+                            >
+                                <Typography
+                                    variant="caption"
+                                    sx={{
+                                        marginBottom: '1px',
+                                        fontSize: '0.75rem',
+                                        fontWeight: isLast ? 'bold' : 'normal',
+                                        display: 'block',
+                                    }}
+                                >
+                                    {keyValue}
+                                </Typography>
+                                <Typography
+                                    variant="caption"
+                                    sx={{
+                                        opacity: isLast ? 0.9 : 0.7,
+                                        fontSize: '0.6rem',
+                                        display: 'block',
+                                    }}
+                                >
+                                    ({keyType})
+                                </Typography>
+                            </Box>
+
+                            {/* Arrow (except for last item) */}
+                            {!isLast && (
+                                <ArrowForwardIcon
+                                    sx={{
+                                        fontSize: 14,
+                                        color: 'text.secondary',
+                                    }}
+                                />
+                            )}
+                        </Box>
+                    );
+                })}
+            </Box>
+        );
+    };
+
+    return (
+        <Box>
+            {renderReferenceKeys()}
+            <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+                Reference Type: {props.reference.type}
+            </Typography>
+        </Box>
+    );
+}

--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/ReferenceComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/ReferenceComponent.tsx
@@ -1,22 +1,39 @@
 import { Typography, Box } from '@mui/material';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import { Reference } from '@aas-core-works/aas-core3.0-typescript/types';
+import { useTranslations } from 'next-intl';
 
 type ReferenceProps = {
     readonly reference: Reference;
+    readonly showAllKeys?: boolean; // Optional prop to control key display
 };
 
 export function ReferenceComponent(props: ReferenceProps) {
+    const { showAllKeys = true } = props;
+    const t = useTranslations('components.referenceComponent');
+
     if (!props.reference.type || props.reference.type === undefined) {
-        return <Typography variant="body2">No type specified</Typography>;
+        return <Typography>{t('noTypeSpecified')}</Typography>;
     }
+
+    const getKeys = () => {
+        const keys = props.reference.keys;
+        if (!keys || !Array.isArray(keys) || keys.length === 0) {
+            return [];
+        }
+        if (!showAllKeys) {
+            return [keys[keys.length - 1]];
+        } else {
+            return keys;
+        }
+    };
 
     const renderReferenceKeys = () => {
         if (!props.reference?.keys || !Array.isArray(props.reference.keys)) {
-            return <Typography variant="body2">No reference path available</Typography>;
+            return <Typography>{t('noReferencePathAvailable')}</Typography>;
         }
 
-        const keys = props.reference.keys;
+        const keys = getKeys();
 
         return (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', marginTop: 1 }}>
@@ -83,7 +100,7 @@ export function ReferenceComponent(props: ReferenceProps) {
         <Box>
             {renderReferenceKeys()}
             <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
-                Reference Type: {props.reference.type}
+                {t('referenceType', { type: props.reference.type })}
             </Typography>
         </Box>
     );

--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/ReferenceElementComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/ReferenceElementComponent.tsx
@@ -1,14 +1,17 @@
 import { ReferenceElement } from '@aas-core-works/aas-core3.0-typescript/types';
 import { Typography } from '@mui/material';
 import { ReferenceComponent } from './ReferenceComponent';
+import { useTranslations } from 'next-intl';
 
 type ReferenceElementComponentProps = {
     readonly refElement: ReferenceElement;
 };
 
 export function ReferenceElementComponent(props: ReferenceElementComponentProps) {
+    const t = useTranslations('components.referenceElementComponent');
+
     if (!props.refElement.value || props.refElement.value === undefined) {
-        return <Typography variant="body2">No value specified</Typography>;
+        return <Typography>{t('noValueSpecified')}</Typography>;
     }
 
     return <ReferenceComponent reference={props.refElement.value} />;

--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/ReferenceElementComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/ReferenceElementComponent.tsx
@@ -1,0 +1,15 @@
+import { ReferenceElement } from '@aas-core-works/aas-core3.0-typescript/types';
+import { Typography } from '@mui/material';
+import { ReferenceComponent } from './ReferenceComponent';
+
+type ReferenceElementComponentProps = {
+    readonly refElement: ReferenceElement;
+};
+
+export function ReferenceElementComponent(props: ReferenceElementComponentProps) {
+    if (!props.refElement.value || props.refElement.value === undefined) {
+        return <Typography variant="body2">No value specified</Typography>;
+    }
+
+    return <ReferenceComponent reference={props.refElement.value} />;
+}

--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/RelationshipElementComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/RelationshipElementComponent.tsx
@@ -1,0 +1,24 @@
+import { RelationshipElement } from '@aas-core-works/aas-core3.0-typescript/types';
+import { Typography } from '@mui/material';
+import { ReferenceComponent } from './ReferenceComponent';
+
+type RelationshipElementComponentProps = {
+    readonly relElement: RelationshipElement;
+};
+
+export function RelationshipElementComponent(props: RelationshipElementComponentProps) {
+    if (!props.relElement.first || props.relElement.first === undefined) {
+        return <Typography variant="body2">No value specified</Typography>;
+    }
+
+    if (!props.relElement.second || props.relElement.second === undefined) {
+        return <Typography variant="body2">No value specified</Typography>;
+    }
+
+    return (
+        <>
+            First: <ReferenceComponent reference={props.relElement.first} />
+            Second: <ReferenceComponent reference={props.relElement.second} />
+        </>
+    );
+}

--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/RelationshipElementComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/RelationshipElementComponent.tsx
@@ -1,24 +1,27 @@
 import { RelationshipElement } from '@aas-core-works/aas-core3.0-typescript/types';
 import { Typography } from '@mui/material';
 import { ReferenceComponent } from './ReferenceComponent';
+import { useTranslations } from 'next-intl';
 
 type RelationshipElementComponentProps = {
     readonly relElement: RelationshipElement;
 };
 
 export function RelationshipElementComponent(props: RelationshipElementComponentProps) {
+    const t = useTranslations('components.relationshipElementComponent');
+
     if (!props.relElement.first || props.relElement.first === undefined) {
-        return <Typography variant="body2">No value specified</Typography>;
+        return <Typography variant="body2">{t('noValueSpecified')}</Typography>;
     }
 
     if (!props.relElement.second || props.relElement.second === undefined) {
-        return <Typography variant="body2">No value specified</Typography>;
+        return <Typography variant="body2">{t('noValueSpecified')}</Typography>;
     }
 
     return (
         <>
-            First: <ReferenceComponent reference={props.relElement.first} />
-            Second: <ReferenceComponent reference={props.relElement.second} />
+            {t('first')}: <ReferenceComponent reference={props.relElement.first} showAllKeys={false} />
+            {t('second')}: <ReferenceComponent reference={props.relElement.second} showAllKeys={false} />
         </>
     );
 }

--- a/src/locale/de.json
+++ b/src/locale/de.json
@@ -159,6 +159,19 @@
         "UNAUTHORIZED": "Nicht autorisiert",
         "UNKNOWN": "Unbekannter Fehler"
       }
+    },
+    "referenceComponent": {
+      "noReferencePathAvailable": "Kein Referenzpfad verfügbar",
+      "noTypeSpecified": "Kein Typ angegeben",
+      "referenceType": "Referenztyp: {type}"
+    },
+    "referenceElementComponent": {
+      "noValueSpecified": "Kein Wert angegeben"
+    },
+    "relationshipElementComponent": {
+      "noValueSpecified": "Kein Wert angegeben",
+      "first": "Erster",
+      "second": "Zweiter"
     }
   },
   "navigation": {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -159,6 +159,19 @@
         "UNAUTHORIZED": "Unauthorized",
         "UNKNOWN": "Unknown error"
       }
+    },
+    "referenceComponent": {
+      "noReferencePathAvailable": "No reference path available",
+      "noTypeSpecified": "No type specified",
+      "referenceType": "Reference type: {type}"
+    },
+    "referenceElementComponent": {
+      "noValueSpecified": "No value specified"
+    },
+    "relationshipElementComponent": {
+      "noValueSpecified": "No value specified",
+      "first": "First",
+      "second": "Second"
     }
   },
   "navigation": {

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -159,6 +159,19 @@
         "UNAUTHORIZED": "No autorizado",
         "UNKNOWN": "Error desconocido"
       }
+    },
+    "referenceComponent": {
+      "noReferencePathAvailable": "No hay ruta de referencia disponible",
+      "noTypeSpecified": "No se especificó ningún tipo",
+      "referenceType": "Tipo de referencia: {type}"
+    },
+    "referenceElementComponent": {
+      "noValueSpecified": "No se especificó ningún valor"
+    },
+    "relationshipElementComponent": {
+      "noValueSpecified": "No se especificó ningún valor",
+      "first": "Primero",
+      "second": "Segundo"
     }
   },
   "navigation": {


### PR DESCRIPTION
# Description

This pull request introduces support for two new submodel element types, `ReferenceElement` and `RelationshipElement`, in the viewer component. It includes the addition of corresponding components, test cases Below is a summary of the most important changes:

### Support for `ReferenceElement` and `RelationshipElement`:

* **GenericSubmodelElementComponent**: Added cases to handle `ReferenceElement` and `RelationshipElement` in the `GenericSubmodelElementComponent` by rendering their respective components. 

* **ReferenceElementComponent**: Introduced a new component to render `ReferenceElement` values. Displays an error message if the value is missing. 

* **RelationshipElementComponent**: Added a new component to render `RelationshipElement` by displaying its `first` and `second` references. Includes error handling for missing references. 

### New `ReferenceComponent`:

* **ReferenceComponent**: Created a reusable component to display reference paths with customizable key display options. Includes robust error handling for missing or invalid data. 

* **ReferenceComponent Tests**: Added test cases for `ReferenceComponent` to validate its behavior under various scenarios, such as missing data, multiple keys, and custom styling. 


## Type of change

Please delete options that are not relevant.

-   [ ] Minor change (non-breaking change, e.g. documentation adaption)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

# Checklist:

-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix or my feature works
-   [ ] New and existing tests pass locally with my changes
-   [ ] My changes contain no console logs
