### PR TITLE
Fix(files): fix relative paths for file submodel element

### DIFF
--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/FileComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/FileComponent.tsx
@@ -9,6 +9,8 @@ import { mapFileDtoToBlob } from 'lib/util/apiResponseWrapper/apiResponseWrapper
 import { useTranslations } from 'next-intl';
 import ImagePreviewDialog from './ImagePreviewDialog';
 import { useCurrentAasContext } from 'components/contexts/CurrentAasContext';
+import { useSession } from 'next-auth/react';
+import { getFileUrl } from 'app/[locale]/viewer/_components/submodel-elements/document-component/DocumentUtils';
 
 const StyledFileImg = styled('img')(() => ({
     objectFit: 'contain',
@@ -22,13 +24,16 @@ type FileComponentProps = {
     readonly submodelId?: string;
     readonly submodelElementPath?: string;
     readonly withPreviewDialog?: boolean;
+    readonly repositoryUrl?: string;
 };
 
-export function FileComponent({ file, submodelId, submodelElementPath, withPreviewDialog = true }: FileComponentProps) {
+export function FileComponent({ file, submodelId, submodelElementPath, withPreviewDialog = true, repositoryUrl }: FileComponentProps) {
     const [image, setImage] = useState<string | null>(null);
+    const [fileUrl, setFileUrl] = useState<string | null>(null);
     const [loading, setLoading] = useState<boolean>(true);
     const [, setLoadError] = useState<boolean>(false);
     const { aasOriginUrl } = useCurrentAasContext();
+    const { data: session } = useSession();
 
     const [previewOpen, setPreviewOpen] = useState(false);
     const [previewFile, setPreviewFile] = useState<ModelFile | null>(null);
@@ -79,9 +84,30 @@ export function FileComponent({ file, submodelId, submodelElementPath, withPrevi
         }
     }
 
+    async function resolveFileUrl() {
+        if (!file.value) {
+            setFileUrl(null);
+            return;
+        }
+
+        if (isValidUrl(file.value)) {
+            setFileUrl(file.value);
+        } else {
+            const repoUrl = repositoryUrl || aasOriginUrl;
+            if (repoUrl && submodelId && submodelElementPath) {
+                const attachmentUrl = `${repoUrl}/submodels/${encodeURIComponent(btoa(submodelId))}/submodel-elements/${submodelElementPath}/attachment`;
+                const resolvedUrl = await getFileUrl(attachmentUrl, session?.accessToken, repoUrl);
+                setFileUrl(resolvedUrl || attachmentUrl);
+            } else {
+                setFileUrl(getSanitizedHref(file.value));
+            }
+        }
+    }
+
     useAsyncEffect(async () => {
         await getImage();
-    }, []);
+        await resolveFileUrl();
+    }, [file.value, session?.accessToken, repositoryUrl, aasOriginUrl, submodelId, submodelElementPath]);
 
     if (!file) {
         return <></>;
@@ -124,9 +150,8 @@ export function FileComponent({ file, submodelId, submodelElementPath, withPrevi
         }
     }
 
-    // Only show link or not available message if image failed to load or isn't an image
-    return file.value ? (
-        <Link href={getSanitizedHref(file.value?.toString())} target="_blank">
+    return fileUrl ? (
+        <Link href={fileUrl} target="_blank">
             <Typography>{file.value?.toString()}</Typography>
         </Link>
     ) : (

--- a/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/GenericSubmodelElementComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/generic-elements/GenericSubmodelElementComponent.tsx
@@ -13,6 +13,7 @@ import { useTranslations } from 'next-intl';
 type GenericSubmodelElementComponentProps = SubmodelElementComponentProps & {
     readonly submodelElementPath?: string | null;
     readonly wrapInDataRow?: boolean;
+    readonly repositoryUrl?: string;
 };
 
 export function GenericSubmodelElementComponent(props: GenericSubmodelElementComponentProps) {
@@ -50,6 +51,7 @@ export function GenericSubmodelElementComponent(props: GenericSubmodelElementCom
                             props.submodelElementPath,
                             props.submodelElement.idShort,
                         )}
+                        repositoryUrl={props.repositoryUrl}
                     />
                 );
             case KeyTypes.MultiLanguageProperty:

--- a/src/app/[locale]/viewer/_components/submodel/generic-submodel/GenericSubmodelDetailComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/generic-submodel/GenericSubmodelDetailComponent.tsx
@@ -51,6 +51,7 @@ export function GenericSubmodelDetailComponent({ submodel, repositoryUrl }: Subm
                                 submodelElement={el}
                                 submodelId={submodel.id}
                                 hasDivider={hasDivider(index)}
+                                repositoryUrl={repositoryUrl}
                             />
                         )}
                     </Fragment>

--- a/src/lib/database/prisma.ts
+++ b/src/lib/database/prisma.ts
@@ -8,7 +8,6 @@ const prismaClientSingleton = () => {
 };
 
 declare global {
-    // eslint-disable-next-line
     var prisma: undefined | ReturnType<typeof prismaClientSingleton>;
 }
 

--- a/src/lib/util/apiResponseWrapper/apiResponseWrapper.ts
+++ b/src/lib/util/apiResponseWrapper/apiResponseWrapper.ts
@@ -77,8 +77,8 @@ export async function wrapResponse<T>(response: Response): Promise<ApiResponseWr
         return wrapErrorCode(status, response.statusText, response.status, result);
     }
 
-    const contentType = response.headers.get('Content-Type') || '';
-    if (!contentType || contentType.includes('application/json')) {
+    const contentType = response.headers.get('Content-Type');
+    if (contentType?.includes('application/json')) {
         if (response.body === null) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             return wrapSuccess(undefined as any);
@@ -88,6 +88,7 @@ export async function wrapResponse<T>(response: Response): Promise<ApiResponseWr
         return wrapSuccess(result, response.status, getStatus(response.status));
     }
 
+    // Default zu Blob für alles andere
     const fileFromResponse = await response.blob();
     return wrapSuccess(fileFromResponse as T, response.status, getStatus(response.status));
 }


### PR DESCRIPTION
This pull request introduces enhancements to the `FileComponent` and related components to improve file URL resolution and handling, along with minor code refinements in other parts of the codebase. The key changes include adding support for resolving file URLs dynamically, propagating the `repositoryUrl` property across components, and refining the `wrapResponse` utility function.

### Enhancements to file URL resolution:

* `FileComponent` (`src/app/[locale]/viewer/_components/submodel-elements/generic-elements/FileComponent.tsx`):
  - Added a new `repositoryUrl` prop and a `fileUrl` state to dynamically resolve file URLs using the `getFileUrl` utility. This ensures proper handling of file links, even when they are not direct URLs. ([src/app/[locale]/viewer/_components/submodel-elements/generic-elements/FileComponent.tsxR27-R36](diffhunk://#diff-066c15cbaa294c1cc7393bd99142539678ff8e8b0182715358c99262a2519163R27-R36), [src/app/[locale]/viewer/_components/submodel-elements/generic-elements/FileComponent.tsxR87-R110](diffhunk://#diff-066c15cbaa294c1cc7393bd99142539678ff8e8b0182715358c99262a2519163R87-R110))
  - Updated the rendering logic to use the resolved `fileUrl` instead of the raw file value. ([src/app/[locale]/viewer/_components/submodel-elements/generic-elements/FileComponent.tsxL127-R154](diffhunk://#diff-066c15cbaa294c1cc7393bd99142539678ff8e8b0182715358c99262a2519163L127-R154))

* `GenericSubmodelElementComponent` and `GenericSubmodelDetailComponent`:
  - Added support for propagating the `repositoryUrl` prop to ensure consistent URL resolution across nested components. ([src/app/[locale]/viewer/_components/submodel-elements/generic-elements/GenericSubmodelElementComponent.tsxR16](diffhunk://#diff-46ec676e0908d66889d41917ea681e573bb36130f80e22b8a9a60085be0d79b0R16), [src/app/[locale]/viewer/_components/submodel-elements/generic-elements/GenericSubmodelElementComponent.tsxR54](diffhunk://#diff-46ec676e0908d66889d41917ea681e573bb36130f80e22b8a9a60085be0d79b0R54), [src/app/[locale]/viewer/_components/submodel/generic-submodel/GenericSubmodelDetailComponent.tsxR54](diffhunk://#diff-2d82c82432b6b870e85b24c222f61fd643d0f1cec2e1b541efc3767a95faddf2R54))

### Refinements to utility functions:

* `apiResponseWrapper.ts` (`src/lib/util/apiResponseWrapper/apiResponseWrapper.ts`):
  - Simplified the `wrapResponse` function by refining content type checks and adding a default fallback to handle non-JSON responses as blobs. [[1]](diffhunk://#diff-944e5edaa6f8a00e6a3bd5d1e7def892b5419d59c2c4aa2d84dbe72bd59c6e9eL80-R81) [[2]](diffhunk://#diff-944e5edaa6f8a00e6a3bd5d1e7def892b5419d59c2c4aa2d84dbe72bd59c6e9eR91)

### Minor code cleanup:

* Removed an unused ESLint directive in the `prismaClientSingleton` declaration.