### PR TITLE
Chore(release): Bump version to 1.6

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,7 +27,7 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: mnestix-browser
   # Update the version manually
-  IMAGE_TAG_VERSION: 1.5.2
+  IMAGE_TAG_VERSION: 1.6.0
 
 jobs:
   build-browser-image:

--- a/compose.yml
+++ b/compose.yml
@@ -10,7 +10,7 @@ volumes:
 services:
   mnestix-browser:
     container_name: mnestix-browser
-    image: mnestix/mnestix-browser:1.5.2
+    image: mnestix/mnestix-browser:1.6.0
     profiles: ['', 'frontend', 'tests']
     build:
       dockerfile: Dockerfile

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mnestix-browser",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "type": "module",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
This pull request updates the version of the `mnestix-browser` application from `1.5.2` to `1.6.0` across multiple files to ensure consistency in the versioning.

### Version update:

* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L30-R30): Updated the `IMAGE_TAG_VERSION` environment variable to `1.6.0` to reflect the new version in the Docker build workflow.
* [`compose.yml`](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L13-R13): Updated the Docker image version for the `mnestix-browser` service to `1.6.0` in the `volumes:` section.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the `version` field to `1.6.0` to align with the new application version.