### PR TITLE
fix(HandoverDocumentComponent): Handle empty documentURL

### DIFF
--- a/src/app/[locale]/viewer/_components/submodel-elements/document-component/DocumentComponent.tsx
+++ b/src/app/[locale]/viewer/_components/submodel-elements/document-component/DocumentComponent.tsx
@@ -45,10 +45,13 @@ export function DocumentComponent(props: CustomSubmodelElementComponentProps) {
     };
 
     function getDocumentClassificationCollection() {
-        return findAllSubmodelElementsBySemanticIdsOrIdShort(props.submodelElement.value, 'DocumentClassification', [
-            DocumentSpecificSemanticId.DocumentClassification,
-            DocumentSpecificSemanticIdIrdi.DocumentClassification,
-        ]) as SubmodelElementCollection[];
+        const result = findAllSubmodelElementsBySemanticIdsOrIdShort(
+            props.submodelElement.value,
+            'DocumentClassification',
+            [DocumentSpecificSemanticId.DocumentClassification, DocumentSpecificSemanticIdIrdi.DocumentClassification],
+        ) as SubmodelElementCollection[];
+
+        return result || [];
     }
 
     return (
@@ -63,13 +66,21 @@ export function DocumentComponent(props: CustomSubmodelElementComponentProps) {
                         sx={{ mb: 1 }}
                     >
                         <Box display="flex" gap={1} flexDirection="row" sx={{ mb: 1 }}>
-                            <Link href={documentUrl} target="_blank">
+                            {documentUrl ? (
+                                <Link href={documentUrl} target="_blank">
+                                    <PreviewImage
+                                        previewImgUrl={fileViewObject.previewImgUrl}
+                                        mimeType={fileViewObject.mimeType}
+                                        repositoryUrl={props.repositoryUrl}
+                                    />
+                                </Link>
+                            ) : (
                                 <PreviewImage
                                     previewImgUrl={fileViewObject.previewImgUrl}
                                     mimeType={fileViewObject.mimeType}
                                     repositoryUrl={props.repositoryUrl}
                                 />
-                            </Link>
+                            )}
                             <Box>
                                 <Typography data-testid="document-title" variant="h5">
                                     {fileViewObject.title}
@@ -79,16 +90,30 @@ export function DocumentComponent(props: CustomSubmodelElementComponentProps) {
                                         {fileViewObject.organizationName}
                                     </Typography>
                                 )}
-                                <Button
-                                    variant="outlined"
-                                    startIcon={<OpenInNew />}
-                                    sx={{ mt: 1 }}
-                                    href={documentUrl}
-                                    target="_blank"
-                                    data-testid="document-open-button"
-                                >
-                                    {t('open')}
-                                </Button>
+                                {documentUrl ? (
+                                    <Button
+                                        variant="outlined"
+                                        startIcon={<OpenInNew />}
+                                        sx={{ mt: 1 }}
+                                        href={documentUrl}
+                                        target="_blank"
+                                        data-testid="document-open-button"
+                                        component="a"
+                                        rel="noopener noreferrer"
+                                    >
+                                        {t('open')}
+                                    </Button>
+                                ) : (
+                                    <Button
+                                        variant="outlined"
+                                        startIcon={<OpenInNew />}
+                                        sx={{ mt: 1 }}
+                                        data-testid="document-open-button"
+                                        disabled
+                                    >
+                                        {t('open')}
+                                    </Button>
+                                )}
                             </Box>
                         </Box>
                         <DocumentClassification


### PR DESCRIPTION
This pull request improves the `DocumentComponent` in `DocumentComponent.tsx` by enhancing its robustness and user experience. The changes include handling edge cases for missing document URLs and ensuring fallback behavior, as well as adding default return values to prevent potential issues.

### Enhancements to robustness:

* Updated the `getDocumentClassificationCollection` function to include a fallback return value (`[]`) when no results are found, ensuring the function always returns a valid array. ([src/app/[locale]/viewer/_components/submodel-elements/document-component/DocumentComponent.tsxL48-R54](diffhunk://#diff-881392a1f5e9bdcdcbed755c69bf2a32b3e286f18e688721c2a031bae2546581L48-R54))

### Improvements to user experience:

* Modified the rendering logic for the preview image and document link. If `documentUrl` is available, the preview image is wrapped in a clickable link; otherwise, it is displayed without a link. ([src/app/[locale]/viewer/_components/submodel-elements/document-component/DocumentComponent.tsxR69-R83](diffhunk://#diff-881392a1f5e9bdcdcbed755c69bf2a32b3e286f18e688721c2a031bae2546581R69-R83))
* Updated the "Open" button to handle cases where `documentUrl` is missing. If `documentUrl` is present, the button links to the document in a new tab with appropriate accessibility attributes (`rel="noopener noreferrer"`). If not, the button is disabled to prevent user confusion. ([src/app/[locale]/viewer/_components/submodel-elements/document-component/DocumentComponent.tsxR93-R116](diffhunk://#diff-881392a1f5e9bdcdcbed755c69bf2a32b3e286f18e688721c2a031bae2546581R93-R116))