### PR TITLE
Feat(infrastructures) add concept descriptions

### DIFF
--- a/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataElement.tsx
+++ b/src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataElement.tsx
@@ -9,6 +9,7 @@ import { buildSubmodelElementPath } from 'lib/util/SubmodelResolverUtil';
 import { getConceptDescriptionById } from 'lib/services/conceptDescriptionApiActions';
 import { useAsyncEffect } from 'lib/hooks/UseAsyncEffect';
 import { GenericPropertyComponent } from '../../submodel-elements/generic-elements/GenericPropertyComponent';
+import { useCurrentAasContext } from 'components/contexts/CurrentAasContext';
 
 export const TechnicalDataElement = (props: {
     elements: SubmodelElementChoice[];
@@ -22,6 +23,7 @@ export const TechnicalDataElement = (props: {
     const theme = useTheme();
     const [conceptDescriptions, setConceptDescriptions] = useState<Record<string, ConceptDescription>>({});
     const [loadingConceptDescriptions, setLoadingConceptDescriptions] = useState<boolean>(true);
+    const infrastructureName = useCurrentAasContext().infrastructureName;
 
     /**
      * Get all semantic IDs from the submodel elements and their children,
@@ -50,7 +52,7 @@ export const TechnicalDataElement = (props: {
         const results = await Promise.all(
             semanticIds.map(async (semanticId) => {
                 if (semanticId) {
-                    const result = await getConceptDescriptionById(semanticId);
+                    const result = await getConceptDescriptionById(semanticId, infrastructureName);
                     if (result.isSuccess) return { [semanticId]: result.result };
                 }
                 return null;

--- a/src/lib/services/conceptDescriptionApiActions.ts
+++ b/src/lib/services/conceptDescriptionApiActions.ts
@@ -3,16 +3,66 @@
 import { mnestixFetch } from 'lib/api/infrastructure';
 import { ApiResponseWrapper, wrapErrorCode } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 import { ApiResultStatus } from 'lib/util/apiResponseWrapper/apiResultStatus';
-import { envs } from 'lib/env/MnestixEnv';
 import { ConceptDescription } from 'lib/api/aas/models';
 import { ConceptDescriptionApi } from 'lib/api/concept-description-api/conceptDescriptionApi';
+import { getInfrastructureByName, getInfrastructuresIncludingDefault } from './database/connectionServerActions';
+import { InfrastructureConnection } from './database/MappedTypes';
+import logger, { logInfo, logResponseDebug } from 'lib/util/Logger';
 
-const conceptDescriptionApi = ConceptDescriptionApi.create(envs.CONCEPT_DESCRIPTION_REPO_API_URL ?? '', mnestixFetch());
+/**
+ * Retrieves a Concept Description by its identifier from one or more Concept Description repositories.
+ *
+ * Search behavior:
+ * - If an infrastructure name is provided, queries only that infrastructure's Concept Description repositories.
+ * - If omitted, discovers all infrastructures (including the default) and queries each repository in order until a match is found.
+ *
+ * Each repository lookup is attempted in sequence; failures for individual repositories are ignored and the search continues with the next repository. The first successful response is returned immediately.
+ *
+ * @param conceptDescriptionId - The identifier of the Concept Description to fetch.
+ * @param infrastructureName - Optional infrastructure name to limit the search. When undefined, all known infrastructures are searched.
+ * @returns A promise resolving to an ApiResponseWrapper<ConceptDescription>. On success, the wrapper has isSuccess=true and contains the Concept Description. If not found in any repository, resolves to an error wrapper with status ApiResultStatus.NOT_FOUND and a message listing the repositories checked.
+ * @throws May throw if infrastructure discovery/lookup fails before repository queries can be attempted (e.g., failing to load infrastructures or an unknown infrastructure name).
+ * @example
+ * // Search across all infrastructures
+ * const res = await getConceptDescriptionById("conceptDescriptionId");
+ * if (res.isSuccess) {
+ *   console.log(res.value);
+ * }
+ *
+ * @example
+ * // Search within a specific infrastructure
+ * const res2 = await getConceptDescriptionById("conceptDescriptionId", "prod-infra");
+ */
+export async function getConceptDescriptionById(conceptDescriptionId: string, infrastructureName: string | undefined = undefined): Promise<ApiResponseWrapper<ConceptDescription>> {
 
-export async function getConceptDescriptionById(submodelId: string): Promise<ApiResponseWrapper<ConceptDescription>> {
-    if (envs.CONCEPT_DESCRIPTION_REPO_API_URL === undefined) {
-        return wrapErrorCode(ApiResultStatus.INTERNAL_SERVER_ERROR, 'Concept Description API URL is not defined');
+    const conceptRepositoryUrls: string[] = [];
+    if (infrastructureName === undefined) {
+        const infrastructures: InfrastructureConnection[] = await getInfrastructuresIncludingDefault();
+        for (const infra of infrastructures) {
+            for (const url of infra.conceptDescriptionRepositoryUrls) {
+                conceptRepositoryUrls.push(url);
+            }
+        }
+    } else {
+        const infrastructure = await getInfrastructureByName(infrastructureName);
+        for (const url of infrastructure.conceptDescriptionRepositoryUrls) {
+            conceptRepositoryUrls.push(url);
+        }
     }
 
-    return conceptDescriptionApi.getConceptDescriptionById(submodelId);
+    for (const url of conceptRepositoryUrls) {
+        const conceptDescriptionApi = ConceptDescriptionApi.create(url, mnestixFetch());
+        try {
+            const response = await conceptDescriptionApi.getConceptDescriptionById(conceptDescriptionId); 
+                if (response.isSuccess) {
+                    return response;
+                } else {
+                    logResponseDebug(logger, 'getConceptDescriptionById', `Couldn't find Concept Description ${conceptDescriptionId} in ${url}`, response);
+                }
+        } catch (error) {
+            logInfo(logger, 'getConceptDescriptionById', `Failed to fetch Concept Description from ${url}`, error);
+        }
+
+    }
+    return wrapErrorCode(ApiResultStatus.NOT_FOUND, `Couldn't find Concept Description in provided infrastructures: ${conceptRepositoryUrls.join(', ')}`);
 }

--- a/src/lib/services/database/MappedTypes.ts
+++ b/src/lib/services/database/MappedTypes.ts
@@ -14,6 +14,7 @@ export type InfrastructureConnection = {
     aasRepositoryUrls: string[];
     submodelRepositoryUrls: string[];
     submodelRegistryUrls: string[];
+    conceptDescriptionRepositoryUrls: string[];
     infrastructureSecurity?: InfrastructureSecurity;
 };
 

--- a/src/lib/services/database/connectionServerActions.ts
+++ b/src/lib/services/database/connectionServerActions.ts
@@ -40,6 +40,9 @@ export async function fetchAllInfrastructureConnectionsFromDb(): Promise<Infrast
         submodelRegistryUrls: infra.connections.flatMap((conn) =>
             conn.types.filter((t) => t.type.typeName === 'SUBMODEL_REGISTRY').map(() => conn.url),
         ),
+        conceptDescriptionRepositoryUrls: infra.connections.flatMap((conn) =>
+            conn.types.filter((t) => t.type.typeName === 'CONCEPT_DESCRIPTION').map(() => conn.url),
+        ),
         infrastructureSecurity: {
             securityType: infra.securityType?.typeName || undefined,
             securitySettingsHeaders: infra.securitySettingsHeaders || undefined,
@@ -48,16 +51,21 @@ export async function fetchAllInfrastructureConnectionsFromDb(): Promise<Infrast
     }));
 }
 
-export async function getInfrastructuresIncludingDefault() {
-    // build default infrastructure from envs
-    const defaultInfrastructure: InfrastructureConnection = {
-        name: 'DefaultInfrastructure',
+export async function getDefaultInfrastructure(): Promise<InfrastructureConnection>{
+    return {
+        name: 'Default Infrastructure',
         discoveryUrls: envs.DISCOVERY_API_URL ? [envs.DISCOVERY_API_URL] : [],
         aasRegistryUrls: envs.REGISTRY_API_URL ? [envs.REGISTRY_API_URL] : [],
         aasRepositoryUrls: envs.AAS_REPO_API_URL ? [envs.AAS_REPO_API_URL] : [],
         submodelRepositoryUrls: envs.SUBMODEL_REPO_API_URL ? [envs.SUBMODEL_REPO_API_URL] : [],
         submodelRegistryUrls: envs.SUBMODEL_REGISTRY_API_URL ? [envs.SUBMODEL_REGISTRY_API_URL] : [],
-    };
+        conceptDescriptionRepositoryUrls: envs.CONCEPT_DESCRIPTION_REPO_API_URL ? [envs.CONCEPT_DESCRIPTION_REPO_API_URL] : [],
+    }
+}
+
+export async function getInfrastructuresIncludingDefault() {
+    // build default infrastructure from envs
+    const defaultInfrastructure = await getDefaultInfrastructure();
 
     // get from database as flat connection list
     const infrastructures = await fetchAllInfrastructureConnectionsFromDb();
@@ -70,7 +78,7 @@ export async function getAasRepositoriesIncludingDefault() {
     const defaultAasRepository = {
         id: 'default',
         url: envs.AAS_REPO_API_URL || '',
-        infrastructureName: 'DefaultInfrastructure',
+        infrastructureName: (await getDefaultInfrastructure()).name,
     };
 
     return [defaultAasRepository, ...aasRepositoriesDb];

--- a/src/lib/services/database/connectionServerActions.ts
+++ b/src/lib/services/database/connectionServerActions.ts
@@ -73,6 +73,15 @@ export async function getInfrastructuresIncludingDefault() {
     return [defaultInfrastructure, ...infrastructures];
 }
 
+export async function getInfrastructureByName(name: string): Promise<InfrastructureConnection> {
+    const infrastructures = await getInfrastructuresIncludingDefault();
+    const found_infrastructure = infrastructures.find(infra => infra.name === name);
+    if (!found_infrastructure) {
+        throw new Error(`Infrastructure with name ${name} not found`);
+    }
+    return found_infrastructure;
+}
+
 export async function getAasRepositoriesIncludingDefault() {
     const aasRepositoriesDb = await getConnectionDataByTypeAction(getTypeAction(ConnectionTypeEnum.AAS_REPOSITORY));
     const defaultAasRepository = {


### PR DESCRIPTION
This pull request introduces infrastructure-aware concept description retrieval and improves how infrastructure data is handled across the application. The main changes include updating the concept description API logic to search repositories associated with specific infrastructures, extending infrastructure data models, and ensuring the UI components correctly handle default and custom infrastructures.

**Infrastructure-aware concept description retrieval:**

* Refactored `getConceptDescriptionById` in `conceptDescriptionApiActions.ts` to search for concept descriptions across all infrastructure repositories if no infrastructure name is provided, or within a specific infrastructure if a name is given. The function now returns more informative errors and logs repository lookup attempts.
* Added support for `conceptDescriptionRepositoryUrls` to the `InfrastructureConnection` type and ensured these URLs are populated when fetching infrastructure data from the database. [[1]](diffhunk://#diff-bb59cbfc5dd03fcddaac3b7063db73bb01995bbd1271295a5d9351a51806b944R17) [[2]](diffhunk://#diff-745be388161b79835992ca60212e33c67a665bca48c6a00abcae92118c5223b5R43-R45)

**Infrastructure data handling and UI updates:**

* Added `getDefaultInfrastructure` and `getInfrastructureByName` helpers in `connectionServerActions.ts` to allow easy retrieval of default and named infrastructures. Updated `getInfrastructuresIncludingDefault` to use these helpers.
* Updated `MnestixInfrastructureCard.tsx` to fetch and store the default infrastructure, and adjusted logic for collecting existing infrastructure names to include the default. This ensures UI components like forms and lists properly reflect all infrastructures. ([src/app/[locale]/settings/_components/mnestix-infrastructure/MnestixInfrastructureCard.tsxR11](diffhunk://#diff-af8760b259cb21f0fd7a0f1ff2774cfef7f9bed308f30e4bec03a5a4f1d80786R11), [src/app/[locale]/settings/_components/mnestix-infrastructure/MnestixInfrastructureCard.tsxR22-R42](diffhunk://#diff-af8760b259cb21f0fd7a0f1ff2774cfef7f9bed308f30e4bec03a5a4f1d80786R22-R42), [src/app/[locale]/settings/_components/mnestix-infrastructure/MnestixInfrastructureCard.tsxR183-R189](diffhunk://#diff-af8760b259cb21f0fd7a0f1ff2774cfef7f9bed308f30e4bec03a5a4f1d80786R183-R189), [src/app/[locale]/settings/_components/mnestix-infrastructure/MnestixInfrastructureCard.tsxL246-R264](diffhunk://#diff-af8760b259cb21f0fd7a0f1ff2774cfef7f9bed308f30e4bec03a5a4f1d80786L246-R264), [src/app/[locale]/settings/_components/mnestix-infrastructure/MnestixInfrastructureCard.tsxL280-R298](diffhunk://#diff-af8760b259cb21f0fd7a0f1ff2774cfef7f9bed308f30e4bec03a5a4f1d80786L280-R298))

**Viewer component enhancements:**

* Modified `TechnicalDataElement.tsx` to use the current infrastructure context when fetching concept descriptions, ensuring that repository queries are scoped appropriately. ([src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataElement.tsxR12](diffhunk://#diff-26486a1c3f5c58262094389848b3dad41f6fd12720a6eadb1152a158bf022aa0R12), [src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataElement.tsxR26](diffhunk://#diff-26486a1c3f5c58262094389848b3dad41f6fd12720a6eadb1152a158bf022aa0R26), [src/app/[locale]/viewer/_components/submodel/technical-data/TechnicalDataElement.tsxL53-R55](diffhunk://#diff-26486a1c3f5c58262094389848b3dad41f6fd12720a6eadb1152a158bf022aa0L53-R55))