### PR TITLE
submodel selector has a max width

### DIFF
--- a/src/app/[locale]/viewer/_components/SubmodelsOverviewCard.tsx
+++ b/src/app/[locale]/viewer/_components/SubmodelsOverviewCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, CardContent, Divider, Skeleton, Typography } from '@mui/material';
+import { Box, Card, CardContent, Divider, Grid, Skeleton, Typography } from '@mui/material';
 import { useEffect, useMemo, useState } from 'react';
 import { useIsMobile } from 'lib/hooks/UseBreakpoints';
 import { SubmodelDetail } from './submodel/SubmodelDetail';
@@ -139,8 +139,8 @@ export function SubmodelsOverviewCard({
                         </Box>
                     ) : (
                         // Content if there are submodels
-                        <Box display="grid" gridTemplateColumns={isMobile ? '1fr' : '1fr 2fr'} gap="2rem">
-                            <Box>
+                        <Grid container spacing={2} alignItems="stretch">
+                            <Grid size={{ md: 4, xs: 12 }}>
                                 <VerticalTabSelector
                                     items={submodelSelectorItems}
                                     selected={selectedItem}
@@ -154,21 +154,23 @@ export function SubmodelsOverviewCard({
                                         data-testid="submodelOverviewLoadingSkeleton"
                                     />
                                 )}
-                            </Box>
-                            {isMobile ? (
-                                <MobileModal
-                                    selectedItem={selectedItem}
-                                    open={!!selectedItem}
-                                    handleClose={() => {
-                                        setSelectedItem(undefined);
-                                    }}
-                                    setInfoItem={setInfoItem}
-                                    content={SelectedContent}
-                                />
-                            ) : (
-                                SelectedContent
-                            )}
-                        </Box>
+                            </Grid>
+                            <Grid size={{ md: 8, xs: 12 }}>
+                                {isMobile ? (
+                                    <MobileModal
+                                        selectedItem={selectedItem}
+                                        open={!!selectedItem}
+                                        handleClose={() => {
+                                            setSelectedItem(undefined);
+                                        }}
+                                        setInfoItem={setInfoItem}
+                                        content={SelectedContent}
+                                    />
+                                ) : (
+                                    SelectedContent
+                                )}
+                            </Grid>
+                        </Grid>
                     )}
                 </CardContent>
             </Card>

--- a/src/components/basics/VerticalTabSelector.tsx
+++ b/src/components/basics/VerticalTabSelector.tsx
@@ -127,7 +127,13 @@ export function VerticalTabSelector(props: VerticalTabSelectorProps) {
                             <Box
                                 display="flex"
                                 alignItems="left"
-                                style={{ whiteSpace: 'nowrap', paddingRight: '20px', maxWidth: '100%' }}
+                                style={{
+                                    whiteSpace: 'nowrap',
+                                    paddingRight: '20px',
+                                    maxWidth: '100%',
+                                    minWidth: 0,
+                                    flex: 1,
+                                }}
                             >
                                 <Typography
                                     sx={{
@@ -141,7 +147,7 @@ export function VerticalTabSelector(props: VerticalTabSelectorProps) {
                                 </Typography>
                             </Box>
 
-                            <Box display="flex" alignItems="center" gap={2}>
+                            <Box display="flex" alignItems="center" gap={2} sx={{ minWidth: 0, flexShrink: 0 }}>
                                 <TooltipContent item={item} />
                                 <ArrowForward color={item.submodelError ? 'disabled' : 'primary'} />
                             </Box>


### PR DESCRIPTION
# Description

This pull request refactors the layout of the `SubmodelsOverviewCard` component to use MUI's `Grid` system for better responsiveness and maintainability, and improves the handling of flexbox sizing in the `VerticalTabSelector` component to address overflow and layout issues.

**Layout and Responsiveness Improvements:**

* Refactored the content layout in `SubmodelsOverviewCard.tsx` from a CSS grid (`Box` with `display="grid"`) to MUI's `Grid` container and items, allowing for more consistent responsive behavior and easier column sizing adjustments. ([src/app/[locale]/viewer/_components/SubmodelsOverviewCard.tsxL142-R143](diffhunk://#diff-f751a698e0190149799b20379dc1ad53eeb05079ee10f7122d4fd05b3ba9e170L142-R143), [src/app/[locale]/viewer/_components/SubmodelsOverviewCard.tsxL157-R158](diffhunk://#diff-f751a698e0190149799b20379dc1ad53eeb05079ee10f7122d4fd05b3ba9e170L157-R158), [src/app/[locale]/viewer/_components/SubmodelsOverviewCard.tsxL171-R173](diffhunk://#diff-f751a698e0190149799b20379dc1ad53eeb05079ee10f7122d4fd05b3ba9e170L171-R173))
* Added the `Grid` component to the imports in `SubmodelsOverviewCard.tsx` to support the new layout. ([src/app/[locale]/viewer/_components/SubmodelsOverviewCard.tsxL1-R1](diffhunk://#diff-f751a698e0190149799b20379dc1ad53eeb05079ee10f7122d4fd05b3ba9e170L1-R1))

**Flexbox and Sizing Fixes:**

* Updated the flexbox styling in `VerticalTabSelector.tsx` to include `minWidth: 0` and `flex: 1` for the main tab label container, preventing unwanted overflow and ensuring proper shrinking/growing within its parent.
* Applied `minWidth: 0` and `flexShrink: 0` to the right-aligned box containing the tooltip and arrow icon in `VerticalTabSelector.tsx`, further improving layout consistency and preventing overflow.