### PR TITLE
chore: Cleanup Concept Description Service

### DIFF
--- a/src/lib/services/concept-description-service/ConceptDescriptionRepositoryService.spec.ts
+++ b/src/lib/services/concept-description-service/ConceptDescriptionRepositoryService.spec.ts
@@ -42,23 +42,6 @@ describe('ConceptDescriptionRepositoryService', () => {
         });
     });
 
-    it('fetches concept description by ID all infrastructures', async () => {
-        const service = ConceptDescriptionRepositoryService.createNull([
-            {
-                searchResult: {
-                    id: 'cd-1',
-                    modelType: 'ConceptDescription',
-                },
-                location: 'https://conceptDescriptionRepo1.com',
-                infrastructureName: 'test1',
-            },
-        ]);
-
-        const result = await service.getConceptDescriptionByIdFromRepositories('cd-1');
-        expect(result.isSuccess).toBe(true);
-        expect(result.result?.id).toBe('cd-1');
-    });
-
     it('fetches concept description by ID from the specified infrastructure', async () => {
         const service = ConceptDescriptionRepositoryService.createNull([
             {
@@ -71,12 +54,44 @@ describe('ConceptDescriptionRepositoryService', () => {
             },
         ]);
 
-        const result = await service.getConceptDescriptionByIdFromRepositories('cd-1', 'test1');
+        const result = await service.getConceptDescriptionByIdFromInfrastructure('cd-1', 'test1');
         expect(result.isSuccess).toBe(true);
         expect(result.result?.id).toBe('cd-1');
     });
 
-    it('does not fetch concept description by ID from the specified infrastructure if not available', async () => {
+    it('fetches concept description by ID from the specified infrastructure with multiple results', async () => {
+        const service = ConceptDescriptionRepositoryService.createNull([
+            {
+                searchResult: {
+                    id: 'cd-1',
+                    modelType: 'ConceptDescription',
+                },
+                location: 'https://conceptDescriptionRepo1.com',
+                infrastructureName: 'test1',
+            },
+            {
+                searchResult: {
+                    id: 'cd-1',
+                    modelType: 'ConceptDescription',
+                },
+                location: 'https://conceptDescriptionRepo2.com',
+                infrastructureName: 'test1',
+            },
+            {
+                searchResult: {
+                    id: 'cd-1',
+                    modelType: 'ConceptDescription',
+                },
+                location: 'https://conceptDescriptionRepo2.com',
+                infrastructureName: 'test1',
+            },
+        ]);
+
+        const result = await service.getConceptDescriptionByIdFromInfrastructure('cd-1', 'test1');
+        expect(result.isSuccess).toBe(true);
+        expect(result.result?.id).toBe('cd-1');
+    });
+    it('does not fetch concept description by ID from the specified infrastructure if id not available', async () => {
         const service = ConceptDescriptionRepositoryService.createNull([
             {
                 searchResult: {
@@ -88,7 +103,23 @@ describe('ConceptDescriptionRepositoryService', () => {
             },
         ]);
 
-        const result = await service.getConceptDescriptionByIdFromRepositories('cd-1', 'default');
+        const result = await service.getConceptDescriptionByIdFromInfrastructure('cd-2', 'test1');
+        expect(result.isSuccess).toBe(false);
+    });
+
+    it('does not fetch concept description by ID from the specified infrastructure if infrastructure not available', async () => {
+        const service = ConceptDescriptionRepositoryService.createNull([
+            {
+                searchResult: {
+                    id: 'cd-1',
+                    modelType: 'ConceptDescription',
+                },
+                location: 'https://conceptDescriptionRepo1.com',
+                infrastructureName: 'test1',
+            },
+        ]);
+
+        const result = await service.getConceptDescriptionByIdFromInfrastructure('cd-1', 'default');
         expect(result.isSuccess).toBe(false);
     });
 });

--- a/src/lib/services/concept-description-service/ConceptDescriptionRepositoryService.spec.ts
+++ b/src/lib/services/concept-description-service/ConceptDescriptionRepositoryService.spec.ts
@@ -59,6 +59,23 @@ describe('ConceptDescriptionRepositoryService', () => {
         expect(result.result?.id).toBe('cd-1');
     });
 
+    it('fetches concept description by ID from all infrastructures', async () => {
+        const service = ConceptDescriptionRepositoryService.createNull([
+            {
+                searchResult: {
+                    id: 'cd-1',
+                    modelType: 'ConceptDescription',
+                },
+                location: 'https://conceptDescriptionRepo1.com',
+                infrastructureName: 'test1',
+            },
+        ]);
+
+        const result = await service.getConceptDescriptionByIdFromAllInfrastructure('cd-1');
+        expect(result.isSuccess).toBe(true);
+        expect(result.result?.id).toBe('cd-1');
+    });
+
     it('fetches concept description by ID from the specified infrastructure with multiple results', async () => {
         const service = ConceptDescriptionRepositoryService.createNull([
             {

--- a/src/lib/services/concept-description-service/ConceptDescriptionRepositoryService.ts
+++ b/src/lib/services/concept-description-service/ConceptDescriptionRepositoryService.ts
@@ -2,8 +2,13 @@ import logger, { logInfo, logResponseDebug } from 'lib/util/Logger';
 import { ConceptDescriptionApi } from 'lib/api/concept-description-api/conceptDescriptionApi';
 import { mnestixFetch } from 'lib/api/infrastructure';
 import { ApiResultStatus } from 'lib/util/apiResponseWrapper/apiResultStatus';
-import { ApiResponseWrapper, wrapErrorCode } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
-import { getInfrastructureByName, getInfrastructuresIncludingDefault } from '../database/infrastructureDatabaseActions';
+import {
+    ApiResponseWrapper,
+    ApiResponseWrapperSuccess,
+    wrapErrorCode,
+    wrapSuccess,
+} from 'lib/util/apiResponseWrapper/apiResponseWrapper';
+import { getInfrastructureByName } from '../database/infrastructureDatabaseActions';
 import { ConceptDescription } from 'lib/api/aas/models';
 import { IConceptDescriptionApi } from 'lib/api/concept-description-api/conceptDescriptionApiInterface';
 import { RepoSearchResult } from 'lib/services/aas-repository-service/AasRepositoryService';
@@ -35,50 +40,85 @@ export class ConceptDescriptionRepositoryService {
         );
     }
 
-    async getConceptDescriptionByIdFromRepositories(
+    async getConceptDescriptionByIdFromSingleRepositoryUrl(
         conceptDescriptionId: string,
-        infrastructureName: string | undefined = undefined,
+        url: string,
     ): Promise<ApiResponseWrapper<ConceptDescription>> {
-        let conceptRepositoryUrlList: string[];
-        if (infrastructureName === undefined) {
-            const infrastructures = await getInfrastructuresIncludingDefault();
-            conceptRepositoryUrlList = infrastructures.flatMap((infra) => infra.conceptDescriptionRepositoryUrls);
-        } else {
-            const infrastructure = await getInfrastructureByName(infrastructureName);
-            if (!infrastructure) {
-                return wrapErrorCode(ApiResultStatus.NOT_FOUND, `Infrastructure with name ${infrastructureName} not found`);
+        const conceptDescriptionApi = this.getConceptDescriptionRepositoryClient(url);
+        try {
+            const response = await conceptDescriptionApi.getConceptDescriptionById(conceptDescriptionId);
+            if (!response.isSuccess) {
+                logResponseDebug(
+                    this.log,
+                    'getConceptDescriptionByIdFromSingleRepository',
+                    `Couldn't find Concept Description ${conceptDescriptionId} in ${url}`,
+                    response,
+                );
             }
-            conceptRepositoryUrlList = infrastructure.conceptDescriptionRepositoryUrls;
+            return response;
+        } catch (error) {
+            logInfo(
+                this.log,
+                'getConceptDescriptionByIdFromSingleRepository',
+                `Failed to fetch Concept Description from ${url}`,
+                error,
+            );
+            return wrapErrorCode(
+                ApiResultStatus.BAD_REQUEST,
+                `Failed to fetch Concept Description ${conceptDescriptionId} from ${url}`,
+            );
         }
-        if (conceptRepositoryUrlList.length === 0) {
+    }
+
+    async getConceptDescriptionByIdFromMultipleRepositoryUrls(
+        conceptDescriptionId: string,
+        repository_urls: string[],
+    ): Promise<ApiResponseWrapper<ConceptDescription>> {
+        const promises = repository_urls.flatMap((url) => {
+            return this.getConceptDescriptionByIdFromSingleRepositoryUrl(conceptDescriptionId, url);
+        });
+        const responses = await Promise.allSettled(promises);
+        const fulfilledResponses = responses.filter((result) => {
+            return result.status == 'fulfilled' && result.value.isSuccess;
+        });
+
+        const allFoundConceptDescriptions = fulfilledResponses.flatMap(
+            (result: PromiseFulfilledResult<ApiResponseWrapperSuccess<ConceptDescription>>) => {
+                return result.value.result;
+            },
+        );
+        if (fulfilledResponses.length < 1 && allFoundConceptDescriptions.length < 1) {
+            return wrapErrorCode(
+                ApiResultStatus.NOT_FOUND,
+                `Failed to fetch Concept Description ${conceptDescriptionId}.`,
+            );
+        }
+
+        return wrapSuccess(allFoundConceptDescriptions[0]);
+    }
+
+    async getConceptDescriptionByIdFromInfrastructure(
+        conceptDescriptionId: string,
+        infrastructureName: string,
+    ): Promise<ApiResponseWrapper<ConceptDescription>> {
+        const infrastructure = await getInfrastructureByName(infrastructureName);
+
+        if (!infrastructure) {
+            return wrapErrorCode(ApiResultStatus.NOT_FOUND, `Infrastructure with name ${infrastructureName} not found`);
+        }
+
+        const conceptRepositoryUrls = new Set(infrastructure.conceptDescriptionRepositoryUrls);
+
+        if (conceptRepositoryUrls.size < 1) {
             return wrapErrorCode(
                 ApiResultStatus.NOT_FOUND,
                 `No Concept Description repositories found for ${infrastructureName !== undefined ? infrastructureName : 'unspecified infrastructure'}`,
             );
         }
 
-        const conceptRepositoryUrls = new Set(conceptRepositoryUrlList);
-        for (const url of conceptRepositoryUrls) {
-            const conceptDescriptionApi = this.getConceptDescriptionRepositoryClient(url);
-            try {
-                const response = await conceptDescriptionApi.getConceptDescriptionById(conceptDescriptionId);
-                if (response.isSuccess) {
-                    return response;
-                } else {
-                    logResponseDebug(
-                        logger,
-                        'getConceptDescriptionById',
-                        `Couldn't find Concept Description ${conceptDescriptionId} in ${url}`,
-                        response,
-                    );
-                }
-            } catch (error) {
-                logInfo(logger, 'getConceptDescriptionById', `Failed to fetch Concept Description from ${url}`, error);
-            }
-        }
-        return wrapErrorCode(
-            ApiResultStatus.NOT_FOUND,
-            `Couldn't find Concept Description in provided infrastructures: ${[...conceptRepositoryUrls].join(', ')}`,
+        return this.getConceptDescriptionByIdFromMultipleRepositoryUrls(
+            conceptDescriptionId,
+            Array.from(conceptRepositoryUrls),
         );
     }
 }

--- a/src/lib/services/concept-description-service/conceptDescriptionRepositoryActions.ts
+++ b/src/lib/services/concept-description-service/conceptDescriptionRepositoryActions.ts
@@ -19,7 +19,7 @@ export async function getConceptDescriptionById(
     if (infrastructureName == undefined) {
         return wrapErrorCode(
             ApiResultStatus.BAD_REQUEST,
-            `No infrastructure name provided to catch ${conceptDescriptionId} from.`,
+            `No infrastructure name provided to fetch ${conceptDescriptionId} from.`,
         );
     }
     const service = ConceptDescriptionRepositoryService.create();

--- a/src/lib/services/concept-description-service/conceptDescriptionRepositoryActions.ts
+++ b/src/lib/services/concept-description-service/conceptDescriptionRepositoryActions.ts
@@ -1,18 +1,27 @@
 'use server';
 
-import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
+import { ApiResponseWrapper, wrapErrorCode } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 import { ConceptDescription } from 'lib/api/aas/models';
 import { ConceptDescriptionRepositoryService } from './ConceptDescriptionRepositoryService';
 import { createRequestLogger, logInfo } from 'lib/util/Logger';
 import { headers } from 'next/headers';
+import { ApiResultStatus } from 'lib/util/apiResponseWrapper/apiResultStatus';
 
-
-export async function getConceptDescriptionById(conceptDescriptionId: string, infrastructureName: string | undefined = undefined): Promise<ApiResponseWrapper<ConceptDescription>> {
+export async function getConceptDescriptionById(
+    conceptDescriptionId: string,
+    infrastructureName: string | undefined = undefined,
+): Promise<ApiResponseWrapper<ConceptDescription>> {
     const logger = createRequestLogger(await headers());
     logInfo(logger, getConceptDescriptionById.name, 'Requested Concept Description', {
         conceptDescriptionId: conceptDescriptionId,
         infrastructureName: infrastructureName,
     });
+    if (infrastructureName == undefined) {
+        return wrapErrorCode(
+            ApiResultStatus.BAD_REQUEST,
+            `No infrastructure name provided to catch ${conceptDescriptionId} from.`,
+        );
+    }
     const service = ConceptDescriptionRepositoryService.create();
-    return service.getConceptDescriptionByIdFromRepositories(conceptDescriptionId, infrastructureName);
+    return service.getConceptDescriptionByIdFromInfrastructure(conceptDescriptionId, infrastructureName);
 }


### PR DESCRIPTION
This pull request refactors the way concept descriptions are fetched by ID from repositories, focusing on improving clarity and reliability when querying by infrastructure. The main changes include renaming methods for better intent, updating the logic to fetch from multiple repository URLs within an infrastructure, and strengthening error handling when infrastructure information is missing or incorrect.

**Refactoring and API improvements:**

* Renamed methods in `ConceptDescriptionRepositoryService` for clarity, replacing `getConceptDescriptionByIdFromRepositories` with `getConceptDescriptionByIdFromInfrastructure`, and reorganized the logic to fetch from all relevant repository URLs within the specified infrastructure.
* Added new helper methods: `getConceptDescriptionByIdFromSingleRepositoryUrl` and `getConceptDescriptionByIdFromMultipleRepositoryUrls` to encapsulate fetching logic and error handling for single and multiple repository URLs.

**Error handling and validation:**

* Updated `conceptDescriptionRepositoryActions.ts` to return a `BAD_REQUEST` error if no infrastructure name is provided, ensuring that requests without required context fail early and clearly.

**Test updates:**

* Updated and expanded unit tests in `ConceptDescriptionRepositoryService.spec.ts` to cover new method names, multiple repository scenarios, and error cases for missing concept descriptions or infrastructures. [[1]](diffhunk://#diff-9f519013f5e0b18ebba38eec1f88a3e4c4396bc4fd796ca7cb10d73fef9e8d1dL45-R45) [[2]](diffhunk://#diff-9f519013f5e0b18ebba38eec1f88a3e4c4396bc4fd796ca7cb10d73fef9e8d1dL57-R62) [[3]](diffhunk://#diff-9f519013f5e0b18ebba38eec1f88a3e4c4396bc4fd796ca7cb10d73fef9e8d1dR72-R110) [[4]](diffhunk://#diff-9f519013f5e0b18ebba38eec1f88a3e4c4396bc4fd796ca7cb10d73fef9e8d1dL91-R122)

**Dependency and import updates:**

* Adjusted imports to include new API response wrapper helpers and removed unused infrastructure database actions for clarity and correctness.