### PR TITLE
Feat(download aas)  merge to branch

### DIFF
--- a/src/lib/api/basyx-v3/api.ts
+++ b/src/lib/api/basyx-v3/api.ts
@@ -13,7 +13,6 @@ import {
 import {
     AssetAdministrationShellRepositoryApiInMemory,
     SubmodelRepositoryApiInMemory,
-    SerializationApiInMemory,
 } from 'lib/api/basyx-v3/apiInMemory';
 import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapper';
 import { AttachmentDetails } from 'lib/types/TransferServiceData';
@@ -803,10 +802,6 @@ export class SerializationApi implements ISerializationApi {
         return new SerializationApi(baseUrl, http, configuration);
     }
 
-    static createNull(baseUrl: string): SerializationApiInMemory {
-        return new SerializationApiInMemory(baseUrl);
-    }
-
     getBaseUrl(): string {
         return this.basePath;
     }
@@ -862,7 +857,7 @@ export const SerializationApiFp = function (configuration?: Configuration) {
                 
                 const localVarHeaderParameter = {
                     Accept: acceptHeader,
-                } as any;
+                };
 
                 localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options?.headers);
 

--- a/src/lib/services/serialization-service/serializationService.ts
+++ b/src/lib/services/serialization-service/serializationService.ts
@@ -34,10 +34,6 @@ export class SerializationService {
         );
     }
 
-    static createNull(): SerializationService {
-        return new SerializationService((baseUrl) => SerializationApi.createNull(baseUrl));
-    }
-
     /**
      * Finds serialization endpoints for a specific infrastructure by name
      */


### PR DESCRIPTION
This pull request refactors the handling of "null" or in-memory implementations for the serialization API and service. The main changes remove the ability to create in-memory or "null" versions of the serialization API and service, simplifying their construction and usage.

Refactoring and simplification of serialization API and service:

* Removed the import of `SerializationApiInMemory` from `apiInMemory`, indicating that in-memory serialization API is no longer supported or required.
* Removed the static `createNull` method from `SerializationApi`, which previously allowed creation of an in-memory serialization API instance.
* Removed the static `createNull` method from `SerializationService`, which previously allowed creation of a service using the in-memory serialization API.

Minor code cleanup:

* Removed unnecessary type assertion in the construction of request headers in `SerializationApiFp`, further simplifying the code.