### PR TITLE
chore: Increase version from 2.2.0 to 2.2.1

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,7 +27,7 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: mnestix-browser
   # Update the version manually
-  IMAGE_TAG_VERSION: 2.2.0
+  IMAGE_TAG_VERSION: 2.2.1
 
 jobs:
   build-browser-image:

--- a/compose.yml
+++ b/compose.yml
@@ -10,7 +10,7 @@ volumes:
 services:
   mnestix-browser:
     container_name: mnestix-browser
-    image: mnestix/mnestix-browser:2.2.0
+    image: mnestix/mnestix-browser:2.2.1
     profiles: ["", "frontend", "tests"]
     build:
       dockerfile: Dockerfile

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mnestix-browser",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
This pull request updates the application version from `2.2.0` to `2.2.1` across the codebase to ensure consistency in versioning. The changes affect the Docker workflow, Docker Compose configuration, and the `package.json` file.

Version update:

* Updated the `IMAGE_TAG_VERSION` in `.github/workflows/docker-build.yml` to `2.2.1` to reflect the new version in the Docker build workflow.
* Updated the Docker image tag in `compose.yml` for the `mnestix-browser` service to use version `2.2.1`.
* Bumped the application version in `package.json` from `2.2.0` to `2.2.1`.