### PR TITLE
fix: regex for AAS viewer

### DIFF
--- a/src/app/[locale]/product/[base64AasId]/page.tsx
+++ b/src/app/[locale]/product/[base64AasId]/page.tsx
@@ -11,7 +11,7 @@ import { ProductViewer } from '../_components/ProductViewer';
 export default function Page() {
     const { showError } = useShowError();
     const params = useParams<{ base64AasId: string }>();
-    const base64AasId = decodeURIComponent(params.base64AasId).replace(/=+$|[%3D]+$/, '');
+    const base64AasId = decodeURIComponent(params.base64AasId).replace(/(=|%3D)+$/i, '');
     const encodedRepoUrl = useSearchParams().get('repoUrl');
     const repoUrl = encodedRepoUrl ? decodeURI(encodedRepoUrl) : undefined;
     const infrastructureName = useSearchParams().get('infrastructure') || undefined;

--- a/src/app/[locale]/product/_components/ProductViewer.tsx
+++ b/src/app/[locale]/product/_components/ProductViewer.tsx
@@ -21,7 +21,7 @@ import { SubmodelElementSemanticIdEnum } from 'lib/enums/SubmodelElementSemantic
 
 export function ProductViewer() {
     const searchParams = useParams<{ base64AasId: string }>();
-    const base64AasId = decodeURIComponent(searchParams.base64AasId).replace(/=+$|[%3D]+$/, '');
+    const base64AasId = decodeURIComponent(searchParams.base64AasId).replace(/(=|%3D)+$/i, '');
     const isMobile = useIsMobile();
     const locale = useLocale();
     const [breadcrumbLinks] = useState<Array<{ label: string; path: string }>>([]);

--- a/src/app/[locale]/viewer/[base64AasId]/page.tsx
+++ b/src/app/[locale]/viewer/[base64AasId]/page.tsx
@@ -10,7 +10,7 @@ import { Box } from '@mui/material';
 export default function () {
     const { showError } = useShowError();
     const params = useParams<{ base64AasId: string }>();
-    const base64AasId = decodeURIComponent(params.base64AasId).replace(/=+$|[%3D]+$/, '');
+    const base64AasId = decodeURIComponent(params.base64AasId).replace(/(=|%3D)+$/i, '');
     const encodedRepoUrl = useSearchParams().get('repoUrl');
     const repoUrl = encodedRepoUrl ? decodeURI(encodedRepoUrl) : undefined;
     const infrastructureName = useSearchParams().get('infrastructure') || undefined;

--- a/src/app/[locale]/viewer/_components/AASViewer.tsx
+++ b/src/app/[locale]/viewer/_components/AASViewer.tsx
@@ -35,7 +35,7 @@ export function AASViewer() {
         useCurrentAasContext();
 
     const params = useParams<{ base64AasId: string }>();
-    const base64AasId = decodeURIComponent(params.base64AasId).replace(/=+$|[%3D]+$/, '');
+    const base64AasId = decodeURIComponent(params.base64AasId).replace(/(=|%3D)+$/i, '');
     const pageStyles = {
         display: 'flex',
         flexDirection: 'column',


### PR DESCRIPTION
# Description

Mnestix Browser couldn't open AAS with base64 encoded IDs ending in 3 or D. Fixed regex that matched html encoded =
