### PR TITLE
feat: recognize MnestixAASGenerator/* qualifier prefix in blueprint editor

### DIFF
--- a/src/app/[locale]/templates/_components/blueprint-edit/edit-components/mapping-info/collection-mapping-info-data.json
+++ b/src/app/[locale]/templates/_components/blueprint-edit/edit-components/mapping-info/collection-mapping-info-data.json
@@ -1,5 +1,5 @@
 {
-  "qualifierTypes": ["CollectionMappingInfo", "SMT/CollectionMappingInfo"],
+  "qualifierTypes": ["CollectionMappingInfo", "SMT/CollectionMappingInfo", "MnestixAASGenerator/CollectionMappingInfo"],
   "emptyTemplate": {
     "semanticId": {
       "type": "ExternalReference",
@@ -11,7 +11,7 @@
       ]
     },
     "kind": "TemplateQualifier",
-    "type": "SMT/CollectionMappingInfo",
+    "type": "MnestixAASGenerator/CollectionMappingInfo",
     "valueType": "xs:string",
     "value": ""
   }

--- a/src/app/[locale]/templates/_components/blueprint-edit/edit-components/mapping-info/filter-mapping-info.json
+++ b/src/app/[locale]/templates/_components/blueprint-edit/edit-components/mapping-info/filter-mapping-info.json
@@ -1,7 +1,8 @@
 {
   "qualifierTypes": [
     "FilterMappingInfo",
-    "SMT/FilterMappingInfo"
+    "SMT/FilterMappingInfo",
+    "MnestixAASGenerator/FilterMappingInfo"
   ],
   "emptyTemplate": {
     "semanticId": {
@@ -14,7 +15,7 @@
       ]
     },
     "kind": "TemplateQualifier",
-    "type": "SMT/FilterMappingInfo",
+    "type": "MnestixAASGenerator/FilterMappingInfo",
     "valueType": "xs:string",
     "value": ""
   }

--- a/src/app/[locale]/templates/_components/blueprint-edit/edit-components/mapping-info/mapping-info-data.json
+++ b/src/app/[locale]/templates/_components/blueprint-edit/edit-components/mapping-info/mapping-info-data.json
@@ -1,5 +1,5 @@
 {
-    "qualifierTypes": ["MappingInfo", "SMT/MappingInfo"],
+    "qualifierTypes": ["MappingInfo", "SMT/MappingInfo", "MnestixAASGenerator/MappingInfo"],
     "emptyTemplate": {
         "semanticId": {
             "type": "ExternalReference",
@@ -11,7 +11,7 @@
             ]
         },
         "kind": "TemplateQualifier",
-        "type": "SMT/MappingInfo",
+        "type": "MnestixAASGenerator/MappingInfo",
         "valueType": "xs:string",
         "value": ""
     }


### PR DESCRIPTION
# Description

The generator now emits MnestixAASGenerator/* qualifiers instead of SMT/* (MNE-428). Add the new prefix to the MappingInfo, CollectionMappingInfo and FilterMappingInfo recognition arrays and emit it from the empty templates. Old SMT/* and plain variants stay supported.

## Related to

- https://github.com/eclipse-mnestix/mnestix-aas-generator/pull/41

## Type of change

-   [x] New feature (non-breaking change which adds functionality)