### PR TITLE
Chore/update license

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @GailMelanie @hofermo @pawel-baran-se @XAlinaGS @LuisSchweinberger 
+* @GailMelanie @hofermo @XAlinaGS @artacho-xitaso

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 XITASO GmbH
+Copyright (c) 2026 XITASO GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/components/basics/AboutDialog.tsx
+++ b/src/components/basics/AboutDialog.tsx
@@ -35,7 +35,7 @@ export function AboutDialog(props: AboutDialogProps) {
                                 {t('about')}
                             </Typography>
                             <Typography color={'primary'}>MIT License</Typography>
-                            <Typography color={'primary'}>Copyright (c) 2024 XITASO GmbH</Typography>
+                            <Typography color={'primary'}>Copyright (c) 2026 XITASO GmbH</Typography>
                         </Box>
                         {!isMobile && (
                             <Box


### PR DESCRIPTION
This pull request contains minor updates to project metadata files. The main changes are an update to the copyright year in the `LICENSE` file and adjustments to the code owners.

- Project metadata updates:
  * Updated the copyright year in the `LICENSE` file from 2024 to 2026.
  * Modified the `.github/CODEOWNERS` file to update the list of code owners.