### PR TITLE
chore: add Eclipse-required root documents

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,93 @@
+# Community Code of Conduct
+
+**Version 2.0  
+January 1, 2023**
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as community members, contributors, Committers[^1], and Project Leads (collectively "Contributors") pledge to make participation in our projects and our community a harassment-free and inclusive experience for everyone.
+
+This Community Code of Conduct ("Code") outlines our behavior expectations as members of our community in all Eclipse Foundation activities, both offline and online. It is not intended to govern scenarios or behaviors outside of the scope of Eclipse Foundation activities. Nor is it intended to replace or supersede the protections offered to all our community members under the law. Please follow both the spirit and letter of this Code and encourage other Contributors to follow these principles into our work. Failure to read or acknowledge this Code does not excuse a Contributor from compliance with the Code.
+
+## Our Standards
+
+Examples of behavior that contribute to creating a positive and professional environment include:
+
+- Using welcoming and inclusive language;
+- Actively encouraging all voices;
+- Helping others bring their perspectives and listening actively. If you find yourself dominating a discussion, it is especially important to encourage other voices to join in;
+- Being respectful of differing viewpoints and experiences;
+- Gracefully accepting constructive criticism;
+- Focusing on what is best for the community;
+- Showing empathy towards other community members;
+- Being direct but professional; and
+- Leading by example by holding yourself and others accountable
+
+Examples of unacceptable behavior by Contributors include:
+
+- The use of sexualized language or imagery;
+- Unwelcome sexual attention or advances;
+- Trolling, insulting/derogatory comments, and personal or political attacks;
+- Public or private harassment, repeated harassment;
+- Publishing others' private information, such as a physical or electronic address, without explicit permission;
+- Violent threats or language directed against another person;
+- Sexist, racist, or otherwise discriminatory jokes and language;
+- Posting sexually explicit or violent material;
+- Sharing private content, such as emails sent privately or non-publicly, or unlogged forums such as IRC channel history;
+- Personal insults, especially those using racist or sexist terms;
+- Excessive or unnecessary profanity;
+- Advocating for, or encouraging, any of the above behavior; and
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+With the support of the Eclipse Foundation employees, consultants, officers, and directors (collectively, the "Staff"), Committers, and Project Leads, the Eclipse Foundation Conduct Committee (the "Conduct Committee") is responsible for clarifying the standards of acceptable behavior. The Conduct Committee takes appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+## Scope
+
+This Code applies within all Project, Working Group, and Interest Group spaces and communication channels of the Eclipse Foundation (collectively, "Eclipse spaces"), within any Eclipse-organized event or meeting, and in public spaces when an individual is representing an Eclipse Foundation Project, Working Group, Interest Group, or their communities. Examples of representing a Project or community include posting via an official social media account, personal accounts, or acting as an appointed representative at an online or offline event. Representation of Projects, Working Groups, and Interest Groups may be further defined and clarified by Committers, Project Leads, or the Staff.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Conduct Committee via conduct@eclipse-foundation.org. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Without the explicit consent of the reporter, the Conduct Committee is obligated to maintain confidentiality with regard to the reporter of an incident. The Conduct Committee is further obligated to ensure that the respondent is provided with sufficient information about the complaint to reply. If such details cannot be provided while maintaining confidentiality, the Conduct Committee will take the respondent‘s inability to provide a defense into account in its deliberations and decisions. Further details of enforcement guidelines may be posted separately.
+
+Staff, Committers and Project Leads have the right to report, remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code, or to block temporarily or permanently any Contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful. Any such actions will be reported to the Conduct Committee for transparency and record keeping.
+
+Any Staff (including officers and directors of the Eclipse Foundation), Committers, Project Leads, or Conduct Committee members who are the subject of a complaint to the Conduct Committee will be recused from the process of resolving any such complaint.
+
+## Responsibility
+
+The responsibility for administering this Code rests with the Conduct Committee, with oversight by the Executive Director and the Board of Directors. For additional information on the Conduct Committee and its process, please write to <conduct@eclipse-foundation.org>.
+
+## Investigation of Potential Code Violations
+
+All conflict is not bad as a healthy debate may sometimes be necessary to push us to do our best. It is, however, unacceptable to be disrespectful or offensive, or violate this Code. If you see someone engaging in objectionable behavior violating this Code, we encourage you to address the behavior directly with those involved. If for some reason, you are unable to resolve the matter or feel uncomfortable doing so, or if the behavior is threatening or harassing, please report it following the procedure laid out below.
+
+Reports should be directed to <conduct@eclipse-foundation.org>. It is the Conduct Committee’s role to receive and address reported violations of this Code and to ensure a fair and speedy resolution.
+
+The Eclipse Foundation takes all reports of potential Code violations seriously and is committed to confidentiality and a full investigation of all allegations. The identity of the reporter will be omitted from the details of the report supplied to the accused. Contributors who are being investigated for a potential Code violation will have an opportunity to be heard prior to any final determination. Those found to have violated the Code can seek reconsideration of the violation and disciplinary action decisions. Every effort will be made to have all matters disposed of within 60 days of the receipt of the complaint.
+
+## Actions
+Contributors who do not follow this Code in good faith may face temporary or permanent repercussions as determined by the Conduct Committee.
+
+This Code does not address all conduct. It works in conjunction with our [Communication Channel Guidelines](https://www.eclipse.org/org/documents/communication-channel-guidelines/), [Social Media Guidelines](https://www.eclipse.org/org/documents/social_media_guidelines.php), [Bylaws](https://www.eclipse.org/org/documents/eclipse-foundation-be-bylaws-en.pdf), and [Internal Rules](https://www.eclipse.org/org/documents/ef-be-internal-rules.pdf) which set out additional protections for, and obligations of, all contributors. The Foundation has additional policies that provide further guidance on other matters.
+
+It’s impossible to spell out every possible scenario that might be deemed a violation of this Code. Instead, we rely on one another’s good judgment to uphold a high standard of integrity within all Eclipse Spaces. Sometimes, identifying the right thing to do isn’t an easy call. In such a scenario, raise the issue as early as possible.
+
+## No Retaliation
+
+The Eclipse community relies upon and values the help of Contributors who identify potential problems that may need to be addressed within an Eclipse Space. Any retaliation against a Contributor who raises an issue honestly is a violation of this Code. That a Contributor has raised a concern honestly or participated in an investigation, cannot be the basis for any adverse action, including threats, harassment, or discrimination. If you work with someone who has raised a concern or provided information in an investigation, you should continue to treat the person with courtesy and respect. If you believe someone has retaliated against you, report the matter as described by this Code. Honest reporting does not mean that you have to be right when you raise a concern; you just have to believe that the information you are providing is accurate.
+
+False reporting, especially when intended to retaliate or exclude, is itself a violation of this Code and will not be accepted or tolerated.
+
+Everyone is encouraged to ask questions about this Code. Your feedback is welcome, and you will get a response within three business days. Write to <conduct@eclipse-foundation.org>.
+
+## Amendments
+
+The Eclipse Foundation Board of Directors may amend this Code from time to time and may vary the procedures it sets out where appropriate in a particular case.
+
+### Attribution
+
+This Code was inspired by the [Contributor Covenant](https://www.contributor-covenant.org/), version 1.4, available [here](https://www.contributor-covenant.org/version/1/4/code-of-conduct/).
+
+[^1]: Capitalized terms used herein without definition shall have the meanings assigned to them in the Bylaws.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,18 @@
+# Contributing to Mnestix
+
 Right now, we are building a community around Mnestix.
 If you are looking for a way to support us, you can start contributing to Mnestix right away.
 For this purpose, issues which are particularly suitable for a first contribution are labeled with the tag
-`good first issue`.  
+`good first issue`.
 
 If this is your first time contributing to an eclipse project, we recommend having a look at this
-guide: [Contributing to a Eclipse project](https://www.eclipse.org/contribute/).  
+guide: [Contributing to a Eclipse project](https://www.eclipse.org/contribute/).
 We would be more than happy to have you on board. If there is anything you want to know, feel free to contact
-us [mnestix@xitaso.com](mailto:mnestix@xitaso.com) or through our website [here](https://xitaso.com/kompetenzen/mnestix/#support).   
+us [mnestix@xitaso.com](mailto:mnestix@xitaso.com) or through our website [here](https://xitaso.com/kompetenzen/mnestix/#support).
+
+## Eclipse Contributor Agreement (ECA)
+
+All contributors must sign the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/eca/) to ensure that the necessary intellectual property (IP) rights to the contribution are granted. You can sign the ECA here: **[accounts.eclipse.org/user/eca](https://accounts.eclipse.org/user/eca)**.
 
 <p align="center">
   <a href="https://xitaso.com/en/competences/mnestix-2/#optin_form">

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,49 @@
+# Notices for Mnestix Browser
+
+This content is produced and maintained by the Eclipse Mnestix project.
+
+* Project home: https://projects.eclipse.org/projects/dt.mnestix
+
+## Trademarks
+
+Mnestix is a trademark of the Eclipse Foundation.
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the MIT License which is available at
+https://opensource.org/license/mit/.
+
+SPDX-License-Identifier: MIT
+
+## Source Code
+
+The project maintains the following source code repositories:
+
+* https://github.com/eclipse-mnestix/mnestix-browser
+* https://github.com/eclipse-mnestix/mnestix-aas-generator
+* https://github.com/eclipse-mnestix/mnestix-proxy
+
+## Third-Party Content
+
+This project depends on third-party open source libraries, declared as npm
+package dependencies in `package.json` (e.g. `next`, `react`, `@mui/material`,
+`next-auth`, `jsonwebtoken`, `lodash`). A verified, complete inventory of
+third-party content and its licenses is being compiled as part of the
+project's Eclipse IP Due Diligence process and will be published as a
+Software Bill of Materials (SBOM) alongside future releases.
+
+## Cryptography
+
+Content may contain encryption software. The country in which you are currently
+may have restrictions on the import, possession, and use, and/or re-export to
+another country, of encryption software. BEFORE using any encryption software,
+please check the country's laws, regulations and policies concerning the import,
+possession, or use, and re-export of encryption software, to see if this is
+permitted.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do **not** report security vulnerabilities through public GitHub issues.
+
+If you believe you have found a security vulnerability in Mnestix Browser, please report it responsibly using one of the following channels:
+
+- **Eclipse Foundation security landing page:** [eclipse.org/security](https://www.eclipse.org/security/) — general guidance on reporting vulnerabilities in Eclipse projects, including a dedicated issue tracker for confidential reports. The Eclipse Foundation's Project Security Incident Response Team (PSIRT) is a registered CVE Numbering Authority (CNA) and coordinates with this project's committers to triage and resolve reports.
+- **Eclipse Foundation security contact:** [security@eclipse-foundation.org](mailto:security@eclipse-foundation.org)
+- **Project contact:** [mnestix@xitaso.com](mailto:mnestix@xitaso.com)
+
+Please include as much detail as possible (affected version, reproduction steps, potential impact) so the report can be triaged quickly.
+
+## Supported Versions
+
+Only the latest released version of Mnestix Browser is supported with security patches.
+
+| Version              | Supported |
+| --------------------- | --------- |
+| Latest release       | ✅        |
+| Older releases        | ❌        |
+
+We recommend always running the most recent release.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -22,7 +22,7 @@
 
 ## Contribution
 
-- [Contributing](Contributing)
+- [Contributing ↗](https://github.com/eclipse-mnestix/mnestix-browser/blob/main/CONTRIBUTING.md)
 
 ## Advanced
 


### PR DESCRIPTION
This is a draft, changes are welcome.

Adds the root-level files required by the [Eclipse Project Handbook](https://www.eclipse.org/projects/handbook/)

    CONTRIBUTING.md
    NOTICE.md
    SECURITY.md
    CODE_OF_CONDUCT.md