### PR TITLE
fix: redirect to repository selection when AAS exists in multiple repos

### DIFF
--- a/src/lib/hooks/UseAasDataLoader.ts
+++ b/src/lib/hooks/UseAasDataLoader.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { Reference, Submodel } from 'lib/api/aas/models';
 import { useEnv } from 'app/EnvProvider';
 import { LocalizedError } from 'lib/util/LocalizedError';
@@ -25,6 +26,7 @@ import { ApiResponseWrapper } from 'lib/util/apiResponseWrapper/apiResponseWrapp
  */
 export function useAasLoader(context: CurrentAasContextType, aasIdToLoad: string, repoUrl: string | undefined) {
     const env = useEnv();
+    const router = useRouter();
     const setIsLoadingAas = context.isLoadingAas[1];
     const setIsLoadingSubmodels = context.isLoadingSubmodels[1];
     const setAasOriginUrl = context.aasOriginUrl[1];
@@ -142,7 +144,11 @@ export function useAasLoader(context: CurrentAasContextType, aasIdToLoad: string
             return;
         }
         setIsLoadingAas(true);
-        await loadAasContent();
+        const result = await loadAasContent();
+        if (!result.success && result.redirectUrl) {
+            router.push(result.redirectUrl);
+            return;
+        }
         setIsLoadingAas(false);
     }, [aasIdToLoad, env, repoUrl]);
 }


### PR DESCRIPTION
# Description

  Fixes the AAS viewer route `/viewer/[AAS-ID]` so it correctly redirects to the
  repository-selection page when the given AAS ID exists in more than one
  configured repository. Previously the redirect URL returned by the search
  service was silently discarded, so users saw an empty/"not found" viewer
  state instead of being able to pick which repository to open — the same
  selection flow already used by the homepage's "Search Asset" field.

  Also fixes a related UI flash where the loading state was cleared right
  before the redirect kicked in, causing the "not found" state to briefly
  appear even when the redirect subsequently succeeded.

  ## Type of change

  Please delete options that are not relevant.

  -   [x] Bug fix (non-breaking change which fixes an issue)

  # Checklist:

  -   [x] I have performed a self-review of my code
  -   [ ] I have commented my code, particularly in hard-to-understand areas
  -   [ ] I have made corresponding changes to the documentation
  -   [x] My changes generate no new warnings
  -   [ ] I have added tests that prove my fix or my feature works
  -   [x] New and existing tests pass locally with my changes
  -   [x] My changes contain no console logs