### PR TITLE
fix: use submodel metadata endpoint in getNameplateValuesForAAS

### DIFF
--- a/src/lib/services/list-service/ListService.ts
+++ b/src/lib/services/list-service/ListService.ts
@@ -136,9 +136,13 @@ export class ListService {
                 let hrefValue = descriptor.endpoints[0].protocolInformation.href;
                 if (hrefValue.startsWith('/')) {
                     const host = new URL(this.repositoryWithInfrastructure.url).origin;
-                    logWarn(this.log, 'getAasListEntities', `Descriptor with id "${descriptor.id}" does not contain a standardconform URL, trying a workaround. Please update your data.`);
+                    logWarn(
+                        this.log,
+                        'getAasListEntities',
+                        `Descriptor with id "${descriptor.id}" does not contain a standardconform URL, trying a workaround. Please update your data.`,
+                    );
                     hrefValue = host.concat(hrefValue);
-                }   
+                }
 
                 const endpoint = new URL(hrefValue);
                 const aasResponse = await targetAasRegistryClient.getAssetAdministrationShellFromEndpoint(endpoint);
@@ -194,11 +198,9 @@ export class ListService {
         for (const reference of submodelReferences.result) {
             const submodelId = reference.keys[0].value;
             const submodelRepositoryClient = this.getTargetSubmodelRepositoryClient();
-            //TODO change request to submodel metadata once Basyx Go supports it
-            //https://github.com/eclipse-basyx/basyx-go-components/issues/307
-            const submodelResponse = await submodelRepositoryClient.getSubmodelById(submodelId);
-            if (submodelResponse.isSuccess) {
-                const semanticId = submodelResponse.result?.semanticId?.keys[0]?.value;
+            const submodelMetadataResponse = await submodelRepositoryClient.getSubmodelMetaData(submodelId);
+            if (submodelMetadataResponse.isSuccess) {
+                const semanticId = submodelMetadataResponse.result?.semanticId?.keys[0]?.value;
                 const nameplateKeys = [
                     SubmodelSemanticIdEnum.NameplateV1,
                     SubmodelSemanticIdEnum.NameplateV2,


### PR DESCRIPTION
# Description 

BaSyx Go's $metadata endpoint (eclipse-basyx/basyx-go-components#307) now works, so we no longer need to fetch the full submodel just to check the semanticId for nameplate detection.

getNameplateValuesForAAS in ListService.ts now calls getSubmodelMetaData() (which requests /submodels/{id}/$metadata) instead of getSubmodelById() when checking a submodel's semanticId for nameplate detection. This avoids transferring the full submodel content (including all submodel elements) just to
inspect the semanticId.

  # Type of change

  Please delete options that are not relevant.

  - [x] Minor change (non-breaking change, e.g. documentation adaption)
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)

  # Checklist:

  - [x] I have performed a self-review of my code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix or my feature works
  - [x] New and existing tests pass locally with my changes
  - [x] My changes contain no console logs