### PR TITLE
chore: Upgrade version number

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,7 +27,7 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: mnestix-browser
   # Update the version manually
-  IMAGE_TAG_VERSION: 2.2.3
+  IMAGE_TAG_VERSION: 2.3.0
 
 jobs:
   build-browser-image:

--- a/compose.yml
+++ b/compose.yml
@@ -10,7 +10,7 @@ volumes:
 services:
   mnestix-browser:
     container_name: mnestix-browser
-    image: mnestix/mnestix-browser:2.2.3
+    image: mnestix/mnestix-browser:2.3.0
     profiles: ["", "frontend", "tests"]
     build:
       dockerfile: Dockerfile

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mnestix-browser",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "type": "module",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
This pull request updates the version of the `mnestix-browser` application from `2.2.3` to `2.3.0` across the project. The version bump is reflected in the application metadata, Docker image references, and deployment configuration.

Version bump and configuration updates:

* Updated the `version` field in `package.json` to `2.3.0` to reflect the new release.
* Changed the Docker image tag in `.github/workflows/docker-build.yml` by updating `IMAGE_TAG_VERSION` to `2.3.0`.
* Updated the Docker image reference in `compose.yml` to use `mnestix/mnestix-browser:2.3.0`.