### PR TITLE
chore: Update AAS Generator to 1.5.0

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -75,7 +75,7 @@ services:
   # NOTE: Requires Mnestix AAS Generator >= 1.3.0 for BaSyx Go (PostgreSQL) compatibility.
   # See https://github.com/eclipse-mnestix/mnestix-aas-generator/wiki/Migrate-to-aas-generator-1.3.0
   mnestix-aas-generator:
-    image: mnestix/mnestix-aas-generator:1.4.0
+    image: mnestix/mnestix-aas-generator:1.5.0
     container_name: mnestix-aas-generator
     profiles: ['', 'backend', 'tests']
     environment:


### PR DESCRIPTION
This pull request updates the `mnestix-aas-generator` service in the `compose.yml` file to use a newer version of its Docker image.

Dependency update:

* Updated the `mnestix-aas-generator` service image from version `1.4.0` to `1.5.0` in `compose.yml` to ensure compatibility with the latest features and fixes.